### PR TITLE
PR-3 feat(auth): domain entities, ports, permissions, bcrypt, JWT, use cases

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,8 @@ pydantic-settings>=2.0.0
 pytest>=9.0.3
 pytest-asyncio>=0.24.0
 aiosqlite>=0.20.0
+bcrypt>=4.1.0
+pyjwt>=2.8.0
 python-dotenv
 ruff
 structlog>=24.0.0

--- a/src/application/use_cases/auth/__init__.py
+++ b/src/application/use_cases/auth/__init__.py
@@ -1,0 +1,1 @@
+"""Auth use cases: registration, login, invitation management."""

--- a/src/application/use_cases/auth/create_invitation.py
+++ b/src/application/use_cases/auth/create_invitation.py
@@ -1,0 +1,46 @@
+"""Create invitation use case.
+
+Handles invitation creation with 7-day expiry and notification dispatch.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from domain.auth.entities import Invitation, UserRole
+from domain.auth.ports import InvitationRepository, NotificationService
+
+
+async def create_invitation(
+    repo: InvitationRepository,
+    notification: NotificationService,
+    inviter_id: str,
+    inviter_name: str,
+    email: str,
+    role: UserRole,
+) -> Invitation:
+    """Create a new invitation and send a notification.
+
+    Args:
+        repo: Invitation repository port.
+        notification: Notification service port.
+        inviter_id: User ID of the admin creating the invitation.
+        inviter_name: Name of the admin (for the notification).
+        email: Invitee email address.
+        role: Role the invitee will receive.
+
+    Returns:
+        The persisted Invitation entity.
+    """
+    invitation = Invitation(
+        id=uuid.uuid4().hex,
+        token=uuid.uuid4().hex,
+        email=email,
+        role=role,
+        inviter_id=inviter_id,
+        expires_at=datetime.now(UTC) + timedelta(days=7),
+    )
+    saved = await repo.save(invitation)
+    await notification.send_invitation(email, invitation.token, inviter_name)
+    return saved

--- a/src/application/use_cases/auth/login_user.py
+++ b/src/application/use_cases/auth/login_user.py
@@ -1,0 +1,38 @@
+"""Login user use case.
+
+Handles user authentication and JWT token generation.
+"""
+
+from __future__ import annotations
+
+from domain.auth.exceptions import AuthenticationError
+from domain.auth.ports import PasswordHasher, TokenService, UserRepository
+
+
+async def login_user(
+    repo: UserRepository,
+    hasher: PasswordHasher,
+    token_service: TokenService,
+    email: str,
+    password: str,
+) -> dict[str, str]:
+    """Authenticate a user and return a JWT token.
+
+    Args:
+        repo: User repository port.
+        hasher: Password hashing port.
+        token_service: Token generation port.
+        email: User email address.
+        password: Plaintext password to verify.
+
+    Returns:
+        Dict with ``access_token`` and ``token_type`` keys.
+
+    Raises:
+        AuthenticationError: If credentials are invalid.
+    """
+    user = await repo.find_by_email(email)
+    if user is None or not hasher.verify(password, user.hashed_password):
+        raise AuthenticationError("Invalid credentials")
+    token = token_service.generate(user.id, user.role.value)
+    return {"access_token": token, "token_type": "bearer"}

--- a/src/application/use_cases/auth/register_user.py
+++ b/src/application/use_cases/auth/register_user.py
@@ -1,0 +1,46 @@
+"""Register user use case.
+
+Handles user registration with duplicate-email detection and password hashing.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from domain.auth.entities import User, UserRole
+from domain.auth.exceptions import UserAlreadyExists
+from domain.auth.ports import PasswordHasher, UserRepository
+
+
+async def register_user(
+    repo: UserRepository,
+    hasher: PasswordHasher,
+    email: str,
+    password: str,
+    role: UserRole = UserRole.USER,
+) -> User:
+    """Register a new user.
+
+    Args:
+        repo: User repository port.
+        hasher: Password hashing port.
+        email: User email address.
+        password: Plaintext password (will be hashed).
+        role: User role (default USER).
+
+    Returns:
+        The persisted User entity.
+
+    Raises:
+        UserAlreadyExists: If a user with the given email already exists.
+    """
+    existing = await repo.find_by_email(email)
+    if existing:
+        raise UserAlreadyExists(f"Email already registered: {email}")
+    user = User(
+        id=uuid.uuid4().hex,
+        email=email,
+        hashed_password=hasher.hash(password),
+        role=role,
+    )
+    return await repo.save(user)

--- a/src/application/use_cases/auth/validate_invitation.py
+++ b/src/application/use_cases/auth/validate_invitation.py
@@ -1,0 +1,38 @@
+"""Validate invitation use case.
+
+Handles invitation token validation: existence, expiry, and usage checks.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from domain.auth.entities import Invitation
+from domain.auth.exceptions import InvitationError
+from domain.auth.ports import InvitationRepository
+
+
+async def validate_invitation(
+    repo: InvitationRepository,
+    token: str,
+) -> Invitation:
+    """Validate an invitation token.
+
+    Args:
+        repo: Invitation repository port.
+        token: The invitation token to validate.
+
+    Returns:
+        The validated Invitation entity.
+
+    Raises:
+        InvitationError: If the token is not found, expired, or already used.
+    """
+    invitation = await repo.find_by_token(token)
+    if invitation is None:
+        raise InvitationError("Invitation not found")
+    if invitation.used_at is not None:
+        raise InvitationError("Invitation already used")
+    if invitation.expires_at and invitation.expires_at < datetime.now(UTC):
+        raise InvitationError("Invitation expired")
+    return invitation

--- a/src/domain/auth/__init__.py
+++ b/src/domain/auth/__init__.py
@@ -1,0 +1,1 @@
+"""Auth domain package: entities, exceptions, ports, permissions."""

--- a/src/domain/auth/entities.py
+++ b/src/domain/auth/entities.py
@@ -1,0 +1,67 @@
+"""Auth domain entities: User, Invitation, UserRole."""
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+
+
+class UserRole(StrEnum):
+    """Role assigned to a user within the system.
+
+    Attributes:
+        ADMIN: Full access, can bypass ownership checks.
+        USER: Standard access, ownership enforced at use-case layer.
+    """
+
+    ADMIN = "admin"
+    USER = "user"
+
+
+@dataclass
+class User:
+    """User entity in the auth domain.
+
+    Attributes:
+        id: Unique identifier (UUID hex).
+        email: User email address.
+        hashed_password: Bcrypt-hashed password.
+        role: Role determining permission level.
+        is_active: Whether the user account is active.
+        created_at: Timestamp of account creation.
+    """
+
+    id: str
+    email: str
+    hashed_password: str
+    role: UserRole = UserRole.USER
+    is_active: bool = True
+    created_at: datetime = field(
+        default_factory=lambda: datetime.now(UTC)
+    )
+
+
+@dataclass
+class Invitation:
+    """Invitation entity for onboarding new users.
+
+    Attributes:
+        id: Unique identifier (UUID hex).
+        token: UUID4 invitation token.
+        email: Invitee email address.
+        role: Role the invitee will receive upon acceptance.
+        inviter_id: User ID of the admin who created the invitation.
+        created_at: Timestamp of invitation creation.
+        expires_at: Expiration timestamp (created_at + 7 days typical).
+        used_at: Timestamp when consumed; None means unused.
+    """
+
+    id: str
+    token: str
+    email: str
+    role: UserRole
+    inviter_id: str
+    created_at: datetime = field(
+        default_factory=lambda: datetime.now(UTC)
+    )
+    expires_at: datetime | None = None
+    used_at: datetime | None = None

--- a/src/domain/auth/exceptions.py
+++ b/src/domain/auth/exceptions.py
@@ -1,0 +1,19 @@
+"""Auth domain exceptions: authentication, authorization, and invitation errors."""
+
+from domain.exceptions import DomainError
+
+
+class AuthenticationError(DomainError):
+    """Raised when authentication fails (invalid credentials, expired token)."""
+
+
+class AuthorizationError(DomainError):
+    """Raised when an authenticated user lacks required permissions."""
+
+
+class UserAlreadyExists(DomainError):  # noqa: N818
+    """Raised when attempting to register with an email that already exists."""
+
+
+class InvitationError(DomainError):
+    """Raised when an invitation is invalid, expired, or already used."""

--- a/src/domain/auth/permissions.py
+++ b/src/domain/auth/permissions.py
@@ -1,0 +1,50 @@
+"""Auth permissions: role-to-operation mapping."""
+
+from enum import StrEnum
+
+from domain.auth.entities import UserRole
+
+
+class Operation(StrEnum):
+    """Discrete permission operations for resource access control.
+
+    Attributes:
+        BOOK_CREATE: Create new books.
+        BOOK_READ: Read books.
+        BOOK_UPDATE: Update existing books.
+        BOOK_DELETE: Delete books.
+        COLLECTION_CREATE: Create collections.
+        COLLECTION_READ: Read collections.
+        COLLECTION_UPDATE: Update collections.
+        COLLECTION_DELETE: Delete collections.
+        FAVORITE_ADD: Add books to favorites.
+        FAVORITE_REMOVE: Remove books from favorites.
+    """
+
+    BOOK_CREATE = "book:create"
+    BOOK_READ = "book:read"
+    BOOK_UPDATE = "book:update"
+    BOOK_DELETE = "book:delete"
+    COLLECTION_CREATE = "collection:create"
+    COLLECTION_READ = "collection:read"
+    COLLECTION_UPDATE = "collection:update"
+    COLLECTION_DELETE = "collection:delete"
+    FAVORITE_ADD = "favorite:add"
+    FAVORITE_REMOVE = "favorite:remove"
+
+
+ROLE_PERMISSIONS: dict[UserRole, set[Operation]] = {
+    UserRole.ADMIN: set(Operation),
+    UserRole.USER: {
+        Operation.BOOK_CREATE,
+        Operation.BOOK_READ,
+        Operation.BOOK_UPDATE,
+        Operation.BOOK_DELETE,
+        Operation.COLLECTION_CREATE,
+        Operation.COLLECTION_READ,
+        Operation.COLLECTION_UPDATE,
+        Operation.COLLECTION_DELETE,
+        Operation.FAVORITE_ADD,
+        Operation.FAVORITE_REMOVE,
+    },
+}

--- a/src/domain/auth/ports.py
+++ b/src/domain/auth/ports.py
@@ -1,0 +1,71 @@
+"""Auth domain ports: abstract interfaces for infrastructure adapters."""
+
+from abc import ABC, abstractmethod
+
+from domain.auth.entities import Invitation, User
+
+
+class UserRepository(ABC):
+    """Port for user persistence."""
+
+    @abstractmethod
+    async def save(self, user: User) -> User:
+        """Persist a user and return the saved entity."""
+
+    @abstractmethod
+    async def find_by_email(self, email: str) -> User | None:
+        """Find a user by email, or None if not found."""
+
+    @abstractmethod
+    async def find_by_id(self, user_id: str) -> User | None:
+        """Find a user by ID, or None if not found."""
+
+
+class PasswordHasher(ABC):
+    """Port for password hashing and verification."""
+
+    @abstractmethod
+    def hash(self, password: str) -> str:
+        """Hash a plaintext password."""
+
+    @abstractmethod
+    def verify(self, password: str, hashed: str) -> bool:
+        """Verify a plaintext password against a hash."""
+
+
+class TokenService(ABC):
+    """Port for JWT token generation and verification."""
+
+    @abstractmethod
+    def generate(self, user_id: str, role: str) -> str:
+        """Generate a signed JWT for the given user."""
+
+    @abstractmethod
+    def verify(self, token: str) -> dict:
+        """Verify a JWT and return its claims dict."""
+
+
+class InvitationRepository(ABC):
+    """Port for invitation persistence."""
+
+    @abstractmethod
+    async def save(self, invitation: Invitation) -> Invitation:
+        """Persist an invitation and return the saved entity."""
+
+    @abstractmethod
+    async def find_by_token(self, token: str) -> Invitation | None:
+        """Find an invitation by its UUID4 token, or None."""
+
+    @abstractmethod
+    async def mark_as_used(self, token: str) -> bool:
+        """Mark an invitation as consumed. Returns True if found and updated."""
+
+
+class NotificationService(ABC):
+    """Port for sending notifications (e.g., invitation emails)."""
+
+    @abstractmethod
+    async def send_invitation(
+        self, email: str, token: str, inviter_name: str
+    ) -> None:
+        """Send an invitation notification to the given email."""

--- a/src/infrastructure/auth/__init__.py
+++ b/src/infrastructure/auth/__init__.py
@@ -1,0 +1,1 @@
+"""Infrastructure auth package."""

--- a/src/infrastructure/auth/bcrypt_password_hasher.py
+++ b/src/infrastructure/auth/bcrypt_password_hasher.py
@@ -1,0 +1,46 @@
+"""Bcrypt-based password hasher implementing the PasswordHasher port."""
+
+import bcrypt
+
+from domain.auth.ports import PasswordHasher
+
+
+class BcryptPasswordHasher(PasswordHasher):
+    """Password hasher using bcrypt with configurable work factor.
+
+    Attributes:
+        rounds: bcrypt cost factor (default 12).
+    """
+
+    def __init__(self, rounds: int = 12) -> None:
+        """Initialize with the given bcrypt rounds.
+
+        Args:
+            rounds: bcrypt cost factor.
+        """
+        self.rounds = rounds
+
+    def hash(self, password: str) -> str:
+        """Hash a plaintext password using bcrypt.
+
+        Args:
+            password: Plaintext password to hash.
+
+        Returns:
+            Bcrypt-hashed password string.
+        """
+        return bcrypt.hashpw(
+            password.encode("utf-8"), bcrypt.gensalt(rounds=self.rounds)
+        ).decode("utf-8")
+
+    def verify(self, password: str, hashed: str) -> bool:
+        """Verify a plaintext password against a bcrypt hash.
+
+        Args:
+            password: Plaintext password to verify.
+            hashed: Bcrypt hash to verify against.
+
+        Returns:
+            True if the password matches, False otherwise.
+        """
+        return bcrypt.checkpw(password.encode("utf-8"), hashed.encode("utf-8"))

--- a/src/infrastructure/auth/jwt_token_service.py
+++ b/src/infrastructure/auth/jwt_token_service.py
@@ -1,0 +1,78 @@
+"""JWT-based token service implementing the TokenService port."""
+
+import time
+from typing import Any
+
+import jwt
+
+from domain.auth.exceptions import AuthenticationError
+from domain.auth.ports import TokenService
+
+DEFAULT_EXPIRE_MINUTES = 30
+
+
+class JwtTokenService(TokenService):
+    """Token service using PyJWT with HS256 signing.
+
+    Attributes:
+        secret_key: HMAC signing key.
+        algorithm: JWT algorithm (default HS256).
+        expire_minutes: Token lifetime in minutes.
+    """
+
+    def __init__(
+        self,
+        secret_key: str,
+        algorithm: str = "HS256",
+        expire_minutes: int = DEFAULT_EXPIRE_MINUTES,
+    ) -> None:
+        """Initialize with signing configuration.
+
+        Args:
+            secret_key: HMAC secret for signing tokens.
+            algorithm: JWT signing algorithm.
+            expire_minutes: Token lifetime in minutes.
+        """
+        self.secret_key = secret_key
+        self.algorithm = algorithm
+        self.expire_minutes = expire_minutes
+
+    def generate(self, user_id: str, role: str) -> str:
+        """Generate a signed JWT for the given user.
+
+        Args:
+            user_id: The user's unique identifier.
+            role: The user's role string.
+
+        Returns:
+            Encoded JWT string.
+        """
+        now = int(time.time())
+        payload: dict[str, Any] = {
+            "sub": user_id,
+            "role": role,
+            "iat": now,
+            "exp": now + (self.expire_minutes * 60),
+        }
+        return jwt.encode(payload, self.secret_key, algorithm=self.algorithm)
+
+    def verify(self, token: str) -> dict:
+        """Verify a JWT and return its claims.
+
+        Args:
+            token: Encoded JWT string.
+
+        Returns:
+            Decoded claims dict with 'sub', 'role', 'exp', 'iat'.
+
+        Raises:
+            AuthenticationError: If token is expired, invalid, or tampered.
+        """
+        try:
+            return jwt.decode(
+                token, self.secret_key, algorithms=[self.algorithm]
+            )
+        except jwt.ExpiredSignatureError as exc:
+            raise AuthenticationError("token has expired") from exc
+        except jwt.InvalidTokenError as exc:
+            raise AuthenticationError("invalid token") from exc

--- a/src/infrastructure/auth/logging_notification_service.py
+++ b/src/infrastructure/auth/logging_notification_service.py
@@ -1,0 +1,39 @@
+"""Logging-based notification service implementing the NotificationService port.
+
+Sends invitation notifications via structured logging (for development /
+testing).  A production adapter would integrate with an email provider.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from domain.auth.ports import NotificationService
+
+logger = logging.getLogger(__name__)
+
+
+class LoggingNotificationService(NotificationService):
+    """NotificationService that logs invitation details.
+
+    The token is truncated in the log output for security — only the
+    first 8 characters are emitted.
+    """
+
+    async def send_invitation(
+        self, email: str, token: str, inviter_name: str
+    ) -> None:
+        """Log an invitation notification.
+
+        Args:
+            email: Invitee email address.
+            token: The invitation token (truncated in log output).
+            inviter_name: Name of the admin who created the invitation.
+        """
+        truncated = f"{token[:8]}..."
+        logger.info(
+            "[INVITATION] To: %s, Token: %s, Inviter: %s",
+            email,
+            truncated,
+            inviter_name,
+        )

--- a/src/infrastructure/auth/sql_invitation_repository.py
+++ b/src/infrastructure/auth/sql_invitation_repository.py
@@ -1,0 +1,116 @@
+"""SQL-backed invitation repository implementation.
+
+Implements the ``InvitationRepository`` port using async SQLAlchemy sessions.
+Domain ``Invitation`` entities are converted to/from ``InvitationModel``
+inline.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from domain.auth.entities import Invitation, UserRole
+from domain.auth.ports import InvitationRepository
+from infrastructure.auth.sql_models import InvitationModel
+
+
+class SQLInvitationRepository(InvitationRepository):
+    """InvitationRepository backed by a SQL database via async SQLAlchemy.
+
+    The session is injected via constructor for testability and
+    per-request scoping.
+
+    Args:
+        session: An AsyncSession instance.
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        """Initialize with an async database session.
+
+        Args:
+            session: Active async SQLAlchemy session for database operations.
+        """
+        self._session = session
+
+    async def save(self, invitation: Invitation) -> Invitation:
+        """Persist an invitation and return the saved entity.
+
+        Args:
+            invitation: Domain Invitation entity to persist.
+
+        Returns:
+            The persisted Invitation entity.
+        """
+        model = InvitationModel(
+            id=invitation.id,
+            token=invitation.token,
+            email=invitation.email,
+            role=invitation.role.value,
+            inviter_id=invitation.inviter_id,
+            created_at=invitation.created_at,
+            expires_at=invitation.expires_at,  # ty: ignore[invalid-argument-type]
+            used_at=invitation.used_at,
+        )
+        self._session.add(model)
+        await self._session.commit()
+        await self._session.refresh(model)
+        return _to_domain(model)
+
+    async def find_by_token(self, token: str) -> Invitation | None:
+        """Find an invitation by its UUID4 token.
+
+        Args:
+            token: The invitation token to search for.
+
+        Returns:
+            Invitation if found, None otherwise.
+        """
+        stmt = select(InvitationModel).where(InvitationModel.token == token)  # ty: ignore[invalid-argument-type]
+        result = await self._session.execute(stmt)
+        model = result.scalar_one_or_none()
+        if model is None:
+            return None
+        return _to_domain(model)
+
+    async def mark_as_used(self, token: str) -> bool:
+        """Mark an invitation as consumed.
+
+        Args:
+            token: The invitation token to mark as used.
+
+        Returns:
+            True if found and updated, False if not found.
+        """
+        stmt = select(InvitationModel).where(InvitationModel.token == token)  # ty: ignore[invalid-argument-type]
+        result = await self._session.execute(stmt)
+        model = result.scalar_one_or_none()
+        if model is None:
+            return False
+        model.used_at = datetime.now(UTC)
+        self._session.add(model)
+        await self._session.commit()
+        return True
+
+
+def _to_domain(model: InvitationModel) -> Invitation:
+    """Convert an InvitationModel to a domain Invitation entity.
+
+    Args:
+        model: The SQLModel database row.
+
+    Returns:
+        Domain Invitation entity.
+    """
+    return Invitation(
+        id=model.id,
+        token=model.token,
+        email=model.email,
+        role=UserRole(model.role),
+        inviter_id=model.inviter_id,
+        created_at=model.created_at,
+        expires_at=model.expires_at,
+        used_at=model.used_at,
+    )

--- a/src/infrastructure/auth/sql_models.py
+++ b/src/infrastructure/auth/sql_models.py
@@ -1,0 +1,61 @@
+"""SQLModel table definitions for auth persistence.
+
+``UserModel`` and ``InvitationModel`` are plain SQLModel data classes —
+NOT domain entities.  They mirror the column structure of the ``users``
+and ``invitations`` tables and are mapped to/from domain entities via
+inline conversion in the repository implementations.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlmodel import Field, SQLModel
+
+
+class UserModel(SQLModel, table=True):  # type: ignore[call-arg]
+    """SQLModel table for users.
+
+    Attributes:
+        id: Primary key (UUID hex string).
+        email: User email address (unique, indexed).
+        hashed_password: Bcrypt-hashed password.
+        role: Role string (``"user"`` or ``"admin"``).
+        is_active: Whether the account is active.
+        created_at: Account creation timestamp.
+    """
+
+    __tablename__ = "users"
+
+    id: str = Field(primary_key=True)
+    email: str = Field(index=True, unique=True)
+    hashed_password: str
+    role: str = "user"
+    is_active: bool = True
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+
+class InvitationModel(SQLModel, table=True):  # type: ignore[call-arg]
+    """SQLModel table for invitations.
+
+    Attributes:
+        id: Primary key (UUID hex string).
+        token: UUID4 invitation token (unique, indexed).
+        email: Invitee email address.
+        role: Role string the invitee will receive.
+        inviter_id: User ID of the admin who created the invitation.
+        created_at: Invitation creation timestamp.
+        expires_at: Expiration timestamp.
+        used_at: When consumed; None means unused.
+    """
+
+    __tablename__ = "invitations"
+
+    id: str = Field(primary_key=True)
+    token: str = Field(index=True, unique=True)
+    email: str
+    role: str
+    inviter_id: str
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    expires_at: datetime
+    used_at: datetime | None = Field(default=None)

--- a/src/infrastructure/auth/sql_user_repository.py
+++ b/src/infrastructure/auth/sql_user_repository.py
@@ -1,0 +1,104 @@
+"""SQL-backed user repository implementation.
+
+Implements the ``UserRepository`` port using async SQLAlchemy sessions.
+Domain ``User`` entities are converted to/from ``UserModel`` inline.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from domain.auth.entities import User, UserRole
+from domain.auth.ports import UserRepository
+from infrastructure.auth.sql_models import UserModel
+
+
+class SQLUserRepository(UserRepository):
+    """UserRepository backed by a SQL database via async SQLAlchemy.
+
+    The session is injected via constructor for testability and
+    per-request scoping.
+
+    Args:
+        session: An AsyncSession instance.
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        """Initialize with an async database session.
+
+        Args:
+            session: Active async SQLAlchemy session for database operations.
+        """
+        self._session = session
+
+    async def save(self, user: User) -> User:
+        """Persist a user and return the saved entity.
+
+        Args:
+            user: Domain User entity to persist.
+
+        Returns:
+            The persisted User entity.
+        """
+        model = UserModel(
+            id=user.id,
+            email=user.email,
+            hashed_password=user.hashed_password,
+            role=user.role.value,
+            is_active=user.is_active,
+            created_at=user.created_at,
+        )
+        self._session.add(model)
+        await self._session.commit()
+        await self._session.refresh(model)
+        return _to_domain(model)
+
+    async def find_by_email(self, email: str) -> User | None:
+        """Find a user by email address.
+
+        Args:
+            email: Email address to search for.
+
+        Returns:
+            User if found, None otherwise.
+        """
+        stmt = select(UserModel).where(UserModel.email == email)  # ty: ignore[invalid-argument-type]
+        result = await self._session.execute(stmt)
+        model = result.scalar_one_or_none()
+        if model is None:
+            return None
+        return _to_domain(model)
+
+    async def find_by_id(self, user_id: str) -> User | None:
+        """Find a user by ID.
+
+        Args:
+            user_id: Unique identifier of the user.
+
+        Returns:
+            User if found, None otherwise.
+        """
+        model = await self._session.get(UserModel, user_id)
+        if model is None:
+            return None
+        return _to_domain(model)
+
+
+def _to_domain(model: UserModel) -> User:
+    """Convert a UserModel to a domain User entity.
+
+    Args:
+        model: The SQLModel database row.
+
+    Returns:
+        Domain User entity.
+    """
+    return User(
+        id=model.id,
+        email=model.email,
+        hashed_password=model.hashed_password,
+        role=UserRole(model.role),
+        is_active=model.is_active,
+        created_at=model.created_at,
+    )

--- a/tests/unit/auth/test_bcrypt_hasher.py
+++ b/tests/unit/auth/test_bcrypt_hasher.py
@@ -1,0 +1,63 @@
+"""Unit tests for BcryptPasswordHasher."""
+
+
+from infrastructure.auth.bcrypt_password_hasher import BcryptPasswordHasher
+
+
+class TestBcryptPasswordHasher:
+    """Test BcryptPasswordHasher implements PasswordHasher correctly."""
+
+    def setup_method(self) -> None:
+        """Create a fresh hasher for each test."""
+        self.hasher = BcryptPasswordHasher()
+
+    def test_hash_returns_non_empty_string(self) -> None:
+        """Hash returns a non-empty string."""
+        result = self.hasher.hash("password123")
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_hash_returns_different_string_than_input(self) -> None:
+        """Hash output is not the same as the input password."""
+        result = self.hasher.hash("password123")
+        assert result != "password123"
+
+    def test_hash_is_deterministic_different_hashes(self) -> None:
+        """Hashing the same password twice produces different hashes (different salts)."""
+        hash1 = self.hasher.hash("password123")
+        hash2 = self.hasher.hash("password123")
+        assert hash1 != hash2
+
+    def test_verify_correct_password_returns_true(self) -> None:
+        """Verify returns True when password matches the hash."""
+        hashed = self.hasher.hash("password123")
+        assert self.hasher.verify("password123", hashed) is True
+
+    def test_verify_wrong_password_returns_false(self) -> None:
+        """Verify returns False when password does not match the hash."""
+        hashed = self.hasher.hash("password123")
+        assert self.hasher.verify("wrongpassword", hashed) is False
+
+    def test_verify_empty_password_against_hash(self) -> None:
+        """Verify returns False for empty password against a non-empty hash."""
+        hashed = self.hasher.hash("password123")
+        assert self.hasher.verify("", hashed) is False
+
+    def test_hash_empty_password(self) -> None:
+        """Hashing an empty password still produces a valid hash."""
+        hashed = self.hasher.hash("")
+        assert isinstance(hashed, str)
+        assert len(hashed) > 0
+        assert self.hasher.verify("", hashed) is True
+
+    def test_hash_unicode_password(self) -> None:
+        """Hashing a unicode password works correctly."""
+        password = "pässwördÜñîçødé"
+        hashed = self.hasher.hash(password)
+        assert self.hasher.verify(password, hashed) is True
+        assert self.hasher.verify("wrong", hashed) is False
+
+    def test_hash_uses_bcrypt_prefix(self) -> None:
+        """Hash output starts with bcrypt identifier prefix."""
+        hashed = self.hasher.hash("test")
+        assert hashed.startswith("$2b$")

--- a/tests/unit/auth/test_create_invitation.py
+++ b/tests/unit/auth/test_create_invitation.py
@@ -1,0 +1,114 @@
+"""Tests for application.use_cases.auth.create_invitation.
+
+Unit tests with mocked dependencies.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock
+
+import pytest
+
+from domain.auth.entities import Invitation, UserRole
+
+
+@pytest.fixture()
+def mock_repo():
+    """Provide a mock InvitationRepository."""
+    repo = AsyncMock()
+    return repo
+
+
+@pytest.fixture()
+def mock_notification():
+    """Provide a mock NotificationService."""
+    return AsyncMock()
+
+
+class TestCreateInvitation:
+    """Tests for create_invitation use case."""
+
+    async def test_create_invitation_saves_and_notifies(
+        self, mock_repo, mock_notification
+    ):
+        """create_invitation() should save the invitation and send notification."""
+        from application.use_cases.auth.create_invitation import create_invitation
+
+        mock_repo.save.return_value = Invitation(
+            id="inv1",
+            token="tok-abc",
+            email="bob@example.com",
+            role=UserRole.USER,
+            inviter_id="admin1",
+            expires_at=datetime.now(UTC) + timedelta(days=7),
+        )
+
+        result = await create_invitation(
+            repo=mock_repo,
+            notification=mock_notification,
+            inviter_id="admin1",
+            inviter_name="Alice",
+            email="bob@example.com",
+            role=UserRole.USER,
+        )
+        assert result.email == "bob@example.com"
+        mock_repo.save.assert_called_once()
+        mock_notification.send_invitation.assert_called_once()
+
+    async def test_create_invitation_sets_7_day_expiry(
+        self, mock_repo, mock_notification
+    ):
+        """create_invitation() should set expires_at to 7 days from now."""
+        from application.use_cases.auth.create_invitation import create_invitation
+
+        mock_repo.save.return_value = Invitation(
+            id="inv1",
+            token="tok-abc",
+            email="bob@example.com",
+            role=UserRole.USER,
+            inviter_id="admin1",
+            expires_at=datetime.now(UTC) + timedelta(days=7),
+        )
+
+        await create_invitation(
+            repo=mock_repo,
+            notification=mock_notification,
+            inviter_id="admin1",
+            inviter_name="Alice",
+            email="bob@example.com",
+            role=UserRole.USER,
+        )
+        saved_inv = mock_repo.save.call_args[0][0]
+        expected_expiry = datetime.now(UTC) + timedelta(days=7)
+        # Allow 5 seconds tolerance for test execution time
+        assert abs((saved_inv.expires_at - expected_expiry).total_seconds()) < 5
+
+    async def test_create_invitation_passes_token_to_notification(
+        self, mock_repo, mock_notification
+    ):
+        """create_invitation() should pass a UUID hex token to the notification."""
+        from application.use_cases.auth.create_invitation import create_invitation
+
+        mock_repo.save.return_value = Invitation(
+            id="inv1",
+            token="tok-abc",
+            email="bob@example.com",
+            role=UserRole.USER,
+            inviter_id="admin1",
+            expires_at=datetime.now(UTC) + timedelta(days=7),
+        )
+
+        await create_invitation(
+            repo=mock_repo,
+            notification=mock_notification,
+            inviter_id="admin1",
+            inviter_name="Alice",
+            email="bob@example.com",
+            role=UserRole.USER,
+        )
+        call_args = mock_notification.send_invitation.call_args
+        token = call_args[0][1]
+        assert call_args[0][0] == "bob@example.com"  # email
+        assert len(token) == 32  # UUID4 hex is 32 chars
+        assert call_args[0][2] == "Alice"  # inviter_name

--- a/tests/unit/auth/test_entities.py
+++ b/tests/unit/auth/test_entities.py
@@ -1,0 +1,124 @@
+"""Unit tests for auth domain entities."""
+
+from datetime import UTC, datetime
+
+from domain.auth.entities import Invitation, User, UserRole
+
+
+class TestUserRole:
+    """Test UserRole enum values."""
+
+    def test_admin_value(self) -> None:
+        """ADMIN enum has string value 'admin'."""
+        assert UserRole.ADMIN.value == "admin"
+
+    def test_user_value(self) -> None:
+        """USER enum has string value 'user'."""
+        assert UserRole.USER.value == "user"
+
+    def test_user_role_is_str_enum(self) -> None:
+        """UserRole members are also strings."""
+        assert isinstance(UserRole.ADMIN, str)
+        assert isinstance(UserRole.USER, str)
+
+
+class TestUser:
+    """Test User dataclass construction and defaults."""
+
+    def test_user_creation_with_all_fields(self) -> None:
+        """User can be constructed with all fields specified."""
+        now = datetime.now(UTC)
+        user = User(
+            id="u1",
+            email="test@example.com",
+            hashed_password="hashed",
+            role=UserRole.ADMIN,
+            is_active=False,
+            created_at=now,
+        )
+        assert user.id == "u1"
+        assert user.email == "test@example.com"
+        assert user.hashed_password == "hashed"
+        assert user.role == UserRole.ADMIN
+        assert user.is_active is False
+        assert user.created_at is now
+
+    def test_user_default_role_is_user(self) -> None:
+        """User defaults to USER role when not specified."""
+        user = User(id="u1", email="a@b.com", hashed_password="h")
+        assert user.role == UserRole.USER
+
+    def test_user_default_is_active_is_true(self) -> None:
+        """User defaults to is_active=True when not specified."""
+        user = User(id="u1", email="a@b.com", hashed_password="h")
+        assert user.is_active is True
+
+    def test_user_default_created_at_is_set(self) -> None:
+        """User gets a created_at timestamp by default."""
+        before = datetime.now(UTC)
+        user = User(id="u1", email="a@b.com", hashed_password="h")
+        after = datetime.now(UTC)
+        assert before <= user.created_at <= after
+
+
+class TestInvitation:
+    """Test Invitation dataclass construction and defaults."""
+
+    def test_invitation_creation_with_all_fields(self) -> None:
+        """Invitation can be constructed with all fields specified."""
+        now = datetime.now(UTC)
+        expires = datetime.now(UTC)
+        used = datetime.now(UTC)
+        inv = Invitation(
+            id="inv1",
+            token="abc-123",
+            email="invite@example.com",
+            role=UserRole.ADMIN,
+            inviter_id="admin1",
+            created_at=now,
+            expires_at=expires,
+            used_at=used,
+        )
+        assert inv.id == "inv1"
+        assert inv.token == "abc-123"
+        assert inv.email == "invite@example.com"
+        assert inv.role == UserRole.ADMIN
+        assert inv.inviter_id == "admin1"
+        assert inv.created_at is now
+        assert inv.expires_at is expires
+        assert inv.used_at is used
+
+    def test_invitation_default_used_at_is_none(self) -> None:
+        """Invitation defaults used_at to None (not yet consumed)."""
+        inv = Invitation(
+            id="inv1",
+            token="abc",
+            email="a@b.com",
+            role=UserRole.USER,
+            inviter_id="admin1",
+        )
+        assert inv.used_at is None
+
+    def test_invitation_default_expires_at_is_none(self) -> None:
+        """Invitation defaults expires_at to None."""
+        inv = Invitation(
+            id="inv1",
+            token="abc",
+            email="a@b.com",
+            role=UserRole.USER,
+            inviter_id="admin1",
+        )
+        assert inv.expires_at is None
+
+    def test_invitation_default_created_at_is_set(self) -> None:
+        """Invitation gets a created_at timestamp by default."""
+        before = datetime.now(UTC)
+        inv = Invitation(
+            id="inv1",
+            token="abc",
+            email="a@b.com",
+            role=UserRole.USER,
+            inviter_id="admin1",
+        )
+        after = datetime.now(UTC)
+        assert before <= inv.created_at <= after

--- a/tests/unit/auth/test_exceptions.py
+++ b/tests/unit/auth/test_exceptions.py
@@ -1,0 +1,66 @@
+"""Unit tests for auth domain exceptions."""
+
+from domain.auth.exceptions import (
+    AuthenticationError,
+    AuthorizationError,
+    InvitationError,
+    UserAlreadyExists,
+)
+from domain.exceptions import DomainError
+
+
+class TestAuthExceptionHierarchy:
+    """Test that all auth exceptions inherit from DomainError."""
+
+    def test_authentication_error_inherits_domain_error(self) -> None:
+        """AuthenticationError is a subclass of DomainError."""
+        assert issubclass(AuthenticationError, DomainError)
+
+    def test_authorization_error_inherits_domain_error(self) -> None:
+        """AuthorizationError is a subclass of DomainError."""
+        assert issubclass(AuthorizationError, DomainError)
+
+    def test_user_already_exists_inherits_domain_error(self) -> None:
+        """UserAlreadyExists is a subclass of DomainError."""
+        assert issubclass(UserAlreadyExists, DomainError)
+
+    def test_invitation_error_inherits_domain_error(self) -> None:
+        """InvitationError is a subclass of DomainError."""
+        assert issubclass(InvitationError, DomainError)
+
+
+class TestAuthExceptionInstantiation:
+    """Test that auth exceptions can be raised and carry messages."""
+
+    def test_authentication_error_with_message(self) -> None:
+        """AuthenticationError can be instantiated with a message."""
+        error = AuthenticationError("invalid credentials")
+        assert str(error) == "invalid credentials"
+
+    def test_authorization_error_with_message(self) -> None:
+        """AuthorizationError can be instantiated with a message."""
+        error = AuthorizationError("insufficient permissions")
+        assert str(error) == "insufficient permissions"
+
+    def test_user_already_exists_with_message(self) -> None:
+        """UserAlreadyExists can be instantiated with a message."""
+        error = UserAlreadyExists("email already registered")
+        assert str(error) == "email already registered"
+
+    def test_invitation_error_with_message(self) -> None:
+        """InvitationError can be instantiated with a message."""
+        error = InvitationError("invitation expired")
+        assert str(error) == "invitation expired"
+
+    def test_auth_exceptions_can_be_caught_as_domain_error(self) -> None:
+        """All auth exceptions can be caught as DomainError."""
+        for exc_class in (
+            AuthenticationError,
+            AuthorizationError,
+            UserAlreadyExists,
+            InvitationError,
+        ):
+            try:
+                raise exc_class("test")
+            except DomainError:
+                pass  # Expected

--- a/tests/unit/auth/test_jwt_token_service.py
+++ b/tests/unit/auth/test_jwt_token_service.py
@@ -1,0 +1,89 @@
+"""Unit tests for JwtTokenService."""
+
+import time
+
+import jwt
+import pytest
+
+from domain.auth.exceptions import AuthenticationError
+from infrastructure.auth.jwt_token_service import JwtTokenService
+
+TEST_SECRET = "test-secret-key-for-jwt-that-is-long-enough"
+TEST_SECRET_WRONG = "wrong-secret-key-for-jwt-that-is-long-enough"
+
+
+class TestJwtTokenServiceGenerate:
+    """Test JwtTokenService.generate method."""
+
+    def setup_method(self) -> None:
+        """Create a fresh token service for each test."""
+        self.service = JwtTokenService(secret_key=TEST_SECRET)
+
+    def test_generate_returns_non_empty_string(self) -> None:
+        """Generate returns a non-empty JWT string."""
+        token = self.service.generate(user_id="u1", role="user")
+        assert isinstance(token, str)
+        assert len(token) > 0
+
+    def test_generate_token_is_valid_jwt(self) -> None:
+        """Generate produces a decodable JWT with expected claims."""
+        token = self.service.generate(user_id="u1", role="admin")
+        claims = jwt.decode(token, TEST_SECRET, algorithms=["HS256"])
+        assert claims["sub"] == "u1"
+        assert claims["role"] == "admin"
+        assert "exp" in claims
+        assert "iat" in claims
+
+    def test_generate_different_users_produce_different_tokens(self) -> None:
+        """Tokens for different users are different."""
+        token1 = self.service.generate(user_id="u1", role="user")
+        token2 = self.service.generate(user_id="u2", role="user")
+        assert token1 != token2
+
+
+class TestJwtTokenServiceVerify:
+    """Test JwtTokenService.verify method."""
+
+    def setup_method(self) -> None:
+        """Create a fresh token service for each test."""
+        self.service = JwtTokenService(secret_key=TEST_SECRET)
+
+    def test_verify_returns_correct_claims(self) -> None:
+        """Verify returns a dict with correct sub and role claims."""
+        token = self.service.generate(user_id="u1", role="admin")
+        claims = self.service.verify(token)
+        assert claims["sub"] == "u1"
+        assert claims["role"] == "admin"
+
+    def test_verify_expired_token_raises_authentication_error(self) -> None:
+        """Verify raises AuthenticationError for an expired token."""
+        # Create a token that expired 1 hour ago
+        payload = {
+            "sub": "u1",
+            "role": "user",
+            "exp": int(time.time()) - 3600,
+            "iat": int(time.time()) - 7200,
+        }
+        token = jwt.encode(payload, TEST_SECRET, algorithm="HS256")
+        with pytest.raises(AuthenticationError, match="expired"):
+            self.service.verify(token)
+
+    def test_verify_tampered_token_raises_authentication_error(self) -> None:
+        """Verify raises AuthenticationError for a token with invalid signature."""
+        token = self.service.generate(user_id="u1", role="user")
+        # Tamper with the token by changing a character
+        tampered = token[:-1] + ("A" if token[-1] != "A" else "B")
+        with pytest.raises(AuthenticationError):
+            self.service.verify(tampered)
+
+    def test_verify_token_with_wrong_key_raises_authentication_error(self) -> None:
+        """Verify raises AuthenticationError when signed with a different key."""
+        other_service = JwtTokenService(secret_key=TEST_SECRET_WRONG)
+        token = other_service.generate(user_id="u1", role="user")
+        with pytest.raises(AuthenticationError):
+            self.service.verify(token)
+
+    def test_verify_malformed_token_raises_authentication_error(self) -> None:
+        """Verify raises AuthenticationError for a completely malformed string."""
+        with pytest.raises(AuthenticationError):
+            self.service.verify("not.a.jwt.token.at.all")

--- a/tests/unit/auth/test_login_user.py
+++ b/tests/unit/auth/test_login_user.py
@@ -1,0 +1,103 @@
+"""Tests for application.use_cases.auth.login_user.
+
+Unit tests with mocked dependencies.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from domain.auth.entities import User, UserRole
+from domain.auth.exceptions import AuthenticationError
+
+
+@pytest.fixture()
+def mock_repo():
+    """Provide a mock UserRepository."""
+    repo = AsyncMock()
+    return repo
+
+
+@pytest.fixture()
+def mock_hasher():
+    """Provide a mock PasswordHasher."""
+    hasher = MagicMock()
+    return hasher
+
+
+@pytest.fixture()
+def mock_token_service():
+    """Provide a mock TokenService."""
+    svc = MagicMock()
+    svc.generate.return_value = "jwt-token-123"
+    return svc
+
+
+class TestLoginUser:
+    """Tests for login_user use case."""
+
+    async def test_login_user_returns_token(
+        self, mock_repo, mock_hasher, mock_token_service
+    ):
+        """login_user() should return access_token on valid credentials."""
+        from application.use_cases.auth.login_user import login_user
+
+        mock_repo.find_by_email.return_value = User(
+            id="u1",
+            email="alice@example.com",
+            hashed_password="$2b$12$hashed",
+            role=UserRole.USER,
+        )
+        mock_hasher.verify.return_value = True
+
+        result = await login_user(
+            repo=mock_repo,
+            hasher=mock_hasher,
+            token_service=mock_token_service,
+            email="alice@example.com",
+            password="secret123",
+        )
+        assert result["access_token"] == "jwt-token-123"
+        assert result["token_type"] == "bearer"
+        mock_token_service.generate.assert_called_once_with("u1", "user")
+
+    async def test_login_user_raises_on_wrong_password(
+        self, mock_repo, mock_hasher, mock_token_service
+    ):
+        """login_user() should raise AuthenticationError on wrong password."""
+        from application.use_cases.auth.login_user import login_user
+
+        mock_repo.find_by_email.return_value = User(
+            id="u1",
+            email="alice@example.com",
+            hashed_password="$2b$12$hashed",
+        )
+        mock_hasher.verify.return_value = False
+
+        with pytest.raises(AuthenticationError):
+            await login_user(
+                repo=mock_repo,
+                hasher=mock_hasher,
+                token_service=mock_token_service,
+                email="alice@example.com",
+                password="wrong",
+            )
+
+    async def test_login_user_raises_on_unknown_email(
+        self, mock_repo, mock_hasher, mock_token_service
+    ):
+        """login_user() should raise AuthenticationError on unknown email."""
+        from application.use_cases.auth.login_user import login_user
+
+        mock_repo.find_by_email.return_value = None
+
+        with pytest.raises(AuthenticationError):
+            await login_user(
+                repo=mock_repo,
+                hasher=mock_hasher,
+                token_service=mock_token_service,
+                email="nobody@example.com",
+                password="secret123",
+            )

--- a/tests/unit/auth/test_notification_service.py
+++ b/tests/unit/auth/test_notification_service.py
@@ -1,0 +1,63 @@
+"""Tests for infrastructure.auth.logging_notification_service.
+
+Unit tests using caplog to verify logging behavior.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture()
+async def service():
+    """Provide a LoggingNotificationService instance."""
+    from infrastructure.auth.logging_notification_service import (
+        LoggingNotificationService,
+    )
+
+    return LoggingNotificationService()
+
+
+class TestLoggingNotificationService:
+    """Tests for send_invitation() logging behavior."""
+
+    async def test_send_invitation_logs_email_and_truncated_token(
+        self, service, caplog
+    ):
+        """send_invitation() should log the email and a truncated token."""
+        import logging
+
+        with caplog.at_level(logging.DEBUG):
+            await service.send_invitation(
+                email="bob@example.com",
+                token="abcdefgh1234567890",
+                inviter_name="Alice",
+            )
+        assert "bob@example.com" in caplog.text
+        assert "abcdefgh..." in caplog.text
+
+    async def test_send_invitation_does_not_log_full_token(self, service, caplog):
+        """send_invitation() should NOT log the full token (security)."""
+        import logging
+
+        full_token = "abcdefgh1234567890"
+        with caplog.at_level(logging.DEBUG):
+            await service.send_invitation(
+                email="bob@example.com",
+                token=full_token,
+                inviter_name="Alice",
+            )
+        # The full token should NOT appear — only the truncated form
+        assert full_token not in caplog.text
+
+    async def test_send_invitation_logs_inviter_name(self, service, caplog):
+        """send_invitation() should log the inviter name."""
+        import logging
+
+        with caplog.at_level(logging.DEBUG):
+            await service.send_invitation(
+                email="bob@example.com",
+                token="abcdefgh1234567890",
+                inviter_name="Alice",
+            )
+        assert "Alice" in caplog.text

--- a/tests/unit/auth/test_permissions.py
+++ b/tests/unit/auth/test_permissions.py
@@ -1,0 +1,72 @@
+"""Unit tests for auth permission mapping."""
+
+from domain.auth.entities import UserRole
+from domain.auth.permissions import ROLE_PERMISSIONS, Operation
+
+
+class TestOperation:
+    """Test Operation enum values."""
+
+    def test_book_create_value(self) -> None:
+        """BOOK_CREATE has correct string value."""
+        assert Operation.BOOK_CREATE.value == "book:create"
+
+    def test_book_read_value(self) -> None:
+        """BOOK_READ has correct string value."""
+        assert Operation.BOOK_READ.value == "book:read"
+
+    def test_book_update_value(self) -> None:
+        """BOOK_UPDATE has correct string value."""
+        assert Operation.BOOK_UPDATE.value == "book:update"
+
+    def test_book_delete_value(self) -> None:
+        """BOOK_DELETE has correct string value."""
+        assert Operation.BOOK_DELETE.value == "book:delete"
+
+    def test_collection_create_value(self) -> None:
+        """COLLECTION_CREATE has correct string value."""
+        assert Operation.COLLECTION_CREATE.value == "collection:create"
+
+    def test_collection_read_value(self) -> None:
+        """COLLECTION_READ has correct string value."""
+        assert Operation.COLLECTION_READ.value == "collection:read"
+
+    def test_collection_update_value(self) -> None:
+        """COLLECTION_UPDATE has correct string value."""
+        assert Operation.COLLECTION_UPDATE.value == "collection:update"
+
+    def test_collection_delete_value(self) -> None:
+        """COLLECTION_DELETE has correct string value."""
+        assert Operation.COLLECTION_DELETE.value == "collection:delete"
+
+    def test_favorite_add_value(self) -> None:
+        """FAVORITE_ADD has correct string value."""
+        assert Operation.FAVORITE_ADD.value == "favorite:add"
+
+    def test_favorite_remove_value(self) -> None:
+        """FAVORITE_REMOVE has correct string value."""
+        assert Operation.FAVORITE_REMOVE.value == "favorite:remove"
+
+
+class TestRolePermissions:
+    """Test ROLE_PERMISSIONS mapping completeness."""
+
+    def test_admin_has_all_operations(self) -> None:
+        """ADMIN role has permission for every Operation."""
+        admin_perms = ROLE_PERMISSIONS[UserRole.ADMIN]
+        assert admin_perms == set(Operation)
+
+    def test_user_has_all_operations(self) -> None:
+        """USER role has permission for every Operation (ownership enforced at use-case layer)."""
+        user_perms = ROLE_PERMISSIONS[UserRole.USER]
+        assert user_perms == set(Operation)
+
+    def test_all_roles_in_mapping(self) -> None:
+        """Every UserRole has an entry in ROLE_PERMISSIONS."""
+        for role in UserRole:
+            assert role in ROLE_PERMISSIONS
+
+    def test_operation_is_str_enum(self) -> None:
+        """Operation members are also strings."""
+        assert isinstance(Operation.BOOK_CREATE, str)
+        assert isinstance(Operation.BOOK_READ, str)

--- a/tests/unit/auth/test_register_user.py
+++ b/tests/unit/auth/test_register_user.py
@@ -1,0 +1,118 @@
+"""Tests for application.use_cases.auth.register_user.
+
+Unit tests with mocked dependencies.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from domain.auth.entities import User, UserRole
+from domain.auth.exceptions import UserAlreadyExists
+
+
+@pytest.fixture()
+def mock_repo():
+    """Provide a mock UserRepository."""
+    repo = AsyncMock()
+    return repo
+
+
+@pytest.fixture()
+def mock_hasher():
+    """Provide a mock PasswordHasher."""
+    hasher = MagicMock()
+    hasher.hash.return_value = "$2b$12$hashed_password"
+    return hasher
+
+
+class TestRegisterUser:
+    """Tests for register_user use case."""
+
+    async def test_register_user_creates_user(self, mock_repo, mock_hasher):
+        """register_user() should create and return a new user."""
+        from application.use_cases.auth.register_user import register_user
+
+        mock_repo.find_by_email.return_value = None
+        mock_repo.save.return_value = User(
+            id="generated",
+            email="alice@example.com",
+            hashed_password="$2b$12$hashed_password",
+            role=UserRole.USER,
+        )
+
+        result = await register_user(
+            repo=mock_repo,
+            hasher=mock_hasher,
+            email="alice@example.com",
+            password="secret123",
+        )
+        assert result.email == "alice@example.com"
+        assert result.role == UserRole.USER
+        mock_repo.save.assert_called_once()
+
+    async def test_register_user_hashes_password(self, mock_repo, mock_hasher):
+        """register_user() should hash the password before saving."""
+        from application.use_cases.auth.register_user import register_user
+
+        mock_repo.find_by_email.return_value = None
+        mock_repo.save.return_value = User(
+            id="generated",
+            email="alice@example.com",
+            hashed_password="$2b$12$hashed_password",
+        )
+
+        await register_user(
+            repo=mock_repo,
+            hasher=mock_hasher,
+            email="alice@example.com",
+            password="secret123",
+        )
+        mock_hasher.hash.assert_called_once_with("secret123")
+        saved_user = mock_repo.save.call_args[0][0]
+        assert saved_user.hashed_password == "$2b$12$hashed_password"
+
+    async def test_register_user_raises_on_duplicate_email(
+        self, mock_repo, mock_hasher
+    ):
+        """register_user() should raise UserAlreadyExists for duplicate email."""
+        from application.use_cases.auth.register_user import register_user
+
+        mock_repo.find_by_email.return_value = User(
+            id="existing",
+            email="alice@example.com",
+            hashed_password="$2b$12$existing",
+        )
+
+        with pytest.raises(UserAlreadyExists):
+            await register_user(
+                repo=mock_repo,
+                hasher=mock_hasher,
+                email="alice@example.com",
+                password="secret123",
+            )
+        mock_repo.save.assert_not_called()
+
+    async def test_register_user_with_admin_role(self, mock_repo, mock_hasher):
+        """register_user() should support creating admin users."""
+        from application.use_cases.auth.register_user import register_user
+
+        mock_repo.find_by_email.return_value = None
+        mock_repo.save.return_value = User(
+            id="generated",
+            email="admin@example.com",
+            hashed_password="$2b$12$hashed_password",
+            role=UserRole.ADMIN,
+        )
+
+        await register_user(
+            repo=mock_repo,
+            hasher=mock_hasher,
+            email="admin@example.com",
+            password="secret123",
+            role=UserRole.ADMIN,
+        )
+        saved_user = mock_repo.save.call_args[0][0]
+        assert saved_user.role == UserRole.ADMIN

--- a/tests/unit/auth/test_sql_invitation_repository.py
+++ b/tests/unit/auth/test_sql_invitation_repository.py
@@ -1,0 +1,104 @@
+"""Tests for infrastructure.auth.sql_invitation_repository.
+
+Integration tests using in-memory SQLite with async sessions.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from domain.auth.entities import Invitation, UserRole
+from infrastructure.persistence.session import create_engine_from_url, create_tables
+
+
+@pytest.fixture()
+async def db_session():
+    """Provide a fresh in-memory async SQLite session with auth tables created."""
+    from infrastructure.persistence.session import get_session
+
+    engine = create_engine_from_url("sqlite://")
+    import infrastructure.auth.sql_models  # noqa: F401
+    await create_tables(engine)
+    async with get_session(engine) as session:
+        yield session
+    await engine.dispose()
+
+
+@pytest.fixture()
+async def repo(db_session):
+    """Provide an SQLInvitationRepository bound to the test session."""
+    from infrastructure.auth.sql_invitation_repository import SQLInvitationRepository
+
+    return SQLInvitationRepository(db_session)
+
+
+def _make_invitation(
+    *,
+    inv_id: str = "inv1",
+    token: str = "tok-abc-123",
+    email: str = "bob@example.com",
+    role: UserRole = UserRole.USER,
+    inviter_id: str = "admin1",
+    expires_at: datetime | None = None,
+    used_at: datetime | None = None,
+) -> Invitation:
+    """Create a test Invitation with sensible defaults."""
+    return Invitation(
+        id=inv_id,
+        token=token,
+        email=email,
+        role=role,
+        inviter_id=inviter_id,
+        expires_at=expires_at or (datetime.now(UTC) + timedelta(days=7)),
+        used_at=used_at,
+    )
+
+
+class TestSQLInvitationRepositorySave:
+    """Tests for save() method."""
+
+    async def test_save_persists_invitation(self, repo):
+        """save() should persist a new invitation and return it."""
+        inv = _make_invitation()
+        saved = await repo.save(inv)
+        assert saved.id == "inv1"
+        assert saved.token == "tok-abc-123"
+        assert saved.email == "bob@example.com"
+        assert saved.role == UserRole.USER
+
+
+class TestSQLInvitationRepositoryFindByToken:
+    """Tests for find_by_token() method."""
+
+    async def test_find_by_token_returns_invitation_when_found(self, repo):
+        """find_by_token() should return the invitation when it exists."""
+        inv = _make_invitation()
+        await repo.save(inv)
+        found = await repo.find_by_token("tok-abc-123")
+        assert found is not None
+        assert found.id == "inv1"
+        assert found.email == "bob@example.com"
+
+    async def test_find_by_token_returns_none_when_not_found(self, repo):
+        """find_by_token() should return None for a nonexistent token."""
+        assert await repo.find_by_token("nonexistent") is None
+
+
+class TestSQLInvitationRepositoryMarkAsUsed:
+    """Tests for mark_as_used() method."""
+
+    async def test_mark_as_used_sets_used_at(self, repo):
+        """mark_as_used() should set used_at and return True."""
+        inv = _make_invitation()
+        await repo.save(inv)
+        result = await repo.mark_as_used("tok-abc-123")
+        assert result is True
+        found = await repo.find_by_token("tok-abc-123")
+        assert found is not None
+        assert found.used_at is not None
+
+    async def test_mark_as_used_returns_false_when_not_found(self, repo):
+        """mark_as_used() should return False for a nonexistent token."""
+        assert await repo.mark_as_used("nonexistent") is False

--- a/tests/unit/auth/test_sql_user_repository.py
+++ b/tests/unit/auth/test_sql_user_repository.py
@@ -1,0 +1,104 @@
+"""Tests for infrastructure.auth.sql_user_repository.
+
+Integration tests using in-memory SQLite with async sessions.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from domain.auth.entities import User, UserRole
+from infrastructure.persistence.session import create_engine_from_url, create_tables
+
+
+@pytest.fixture()
+async def db_session():
+    """Provide a fresh in-memory async SQLite session with auth tables created."""
+    from infrastructure.persistence.session import get_session
+
+    engine = create_engine_from_url("sqlite://")
+    # Import auth models so they register with SQLModel metadata
+    import infrastructure.auth.sql_models  # noqa: F401
+    await create_tables(engine)
+    async with get_session(engine) as session:
+        yield session
+    await engine.dispose()
+
+
+@pytest.fixture()
+async def repo(db_session):
+    """Provide an SQLUserRepository bound to the test session."""
+    from infrastructure.auth.sql_user_repository import SQLUserRepository
+
+    return SQLUserRepository(db_session)
+
+
+class TestSQLUserRepositorySave:
+    """Tests for save() method."""
+
+    async def test_save_persists_user(self, repo):
+        """save() should persist a new user and return it."""
+        user = User(
+            id="u1",
+            email="alice@example.com",
+            hashed_password="$2b$12$hashed",
+            role=UserRole.USER,
+        )
+        saved = await repo.save(user)
+        assert saved.id == "u1"
+        assert saved.email == "alice@example.com"
+        assert saved.role == UserRole.USER
+        assert saved.is_active is True
+
+    async def test_save_persists_admin_role(self, repo):
+        """save() should persist admin role correctly."""
+        user = User(
+            id="u2",
+            email="admin@example.com",
+            hashed_password="$2b$12$hashed",
+            role=UserRole.ADMIN,
+        )
+        saved = await repo.save(user)
+        assert saved.role == UserRole.ADMIN
+
+
+class TestSQLUserRepositoryFindByEmail:
+    """Tests for find_by_email() method."""
+
+    async def test_find_by_email_returns_user_when_found(self, repo):
+        """find_by_email() should return the user when it exists."""
+        user = User(
+            id="u1",
+            email="alice@example.com",
+            hashed_password="$2b$12$hashed",
+        )
+        await repo.save(user)
+        found = await repo.find_by_email("alice@example.com")
+        assert found is not None
+        assert found.id == "u1"
+        assert found.email == "alice@example.com"
+
+    async def test_find_by_email_returns_none_when_not_found(self, repo):
+        """find_by_email() should return None for a nonexistent email."""
+        assert await repo.find_by_email("nobody@example.com") is None
+
+
+class TestSQLUserRepositoryFindById:
+    """Tests for find_by_id() method."""
+
+    async def test_find_by_id_returns_user_when_found(self, repo):
+        """find_by_id() should return the user when it exists."""
+        user = User(
+            id="u1",
+            email="alice@example.com",
+            hashed_password="$2b$12$hashed",
+        )
+        await repo.save(user)
+        found = await repo.find_by_id("u1")
+        assert found is not None
+        assert found.id == "u1"
+        assert found.email == "alice@example.com"
+
+    async def test_find_by_id_returns_none_when_not_found(self, repo):
+        """find_by_id() should return None for a nonexistent id."""
+        assert await repo.find_by_id("nonexistent") is None

--- a/tests/unit/auth/test_validate_invitation.py
+++ b/tests/unit/auth/test_validate_invitation.py
@@ -1,0 +1,83 @@
+"""Tests for application.use_cases.auth.validate_invitation.
+
+Unit tests with mocked dependencies.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock
+
+import pytest
+
+from domain.auth.entities import Invitation, UserRole
+from domain.auth.exceptions import InvitationError
+
+
+@pytest.fixture()
+def mock_repo():
+    """Provide a mock InvitationRepository."""
+    repo = AsyncMock()
+    return repo
+
+
+def _make_invitation(
+    *,
+    used_at: datetime | None = None,
+    expires_at: datetime | None = None,
+) -> Invitation:
+    """Create a test Invitation with sensible defaults."""
+    return Invitation(
+        id="inv1",
+        token="tok-abc",
+        email="bob@example.com",
+        role=UserRole.USER,
+        inviter_id="admin1",
+        expires_at=expires_at or (datetime.now(UTC) + timedelta(days=7)),
+        used_at=used_at,
+    )
+
+
+class TestValidateInvitation:
+    """Tests for validate_invitation use case."""
+
+    async def test_validate_invitation_returns_invitation_on_valid(self, mock_repo):
+        """validate_invitation() should return the invitation when valid."""
+        from application.use_cases.auth.validate_invitation import validate_invitation
+
+        mock_repo.find_by_token.return_value = _make_invitation()
+
+        result = await validate_invitation(repo=mock_repo, token="tok-abc")
+        assert result.email == "bob@example.com"
+        assert result.token == "tok-abc"
+
+    async def test_validate_invitation_raises_when_not_found(self, mock_repo):
+        """validate_invitation() should raise InvitationError when not found."""
+        from application.use_cases.auth.validate_invitation import validate_invitation
+
+        mock_repo.find_by_token.return_value = None
+
+        with pytest.raises(InvitationError):
+            await validate_invitation(repo=mock_repo, token="nonexistent")
+
+    async def test_validate_invitation_raises_when_expired(self, mock_repo):
+        """validate_invitation() should raise InvitationError when expired."""
+        from application.use_cases.auth.validate_invitation import validate_invitation
+
+        mock_repo.find_by_token.return_value = _make_invitation(
+            expires_at=datetime.now(UTC) - timedelta(days=1),
+        )
+
+        with pytest.raises(InvitationError):
+            await validate_invitation(repo=mock_repo, token="tok-abc")
+
+    async def test_validate_invitation_raises_when_already_used(self, mock_repo):
+        """validate_invitation() should raise InvitationError when already used."""
+        from application.use_cases.auth.validate_invitation import validate_invitation
+
+        mock_repo.find_by_token.return_value = _make_invitation(
+            used_at=datetime.now(UTC),
+        )
+
+        with pytest.raises(InvitationError):
+            await validate_invitation(repo=mock_repo, token="tok-abc")


### PR DESCRIPTION
## Chain Context

| Field | Value |
|-------|-------|
| Chain | production-readiness |
| Tracker PR | #3 |
| Position | 3 of 6 |
| Base | feat/production-readiness-02 |
| Depends on | PR-2 |
| Follow-up | PR-4 (Auth API) |

### Scope
Auth domain: User/Invitation entities, UserRole enum, exceptions, ports (UserRepository, PasswordHasher, TokenService, etc.), permissions (Operation + ROLE_PERMISSIONS), BcryptPasswordHasher (rounds=12), JwtTokenService (HS256, 30min). Auth infra: UserModel/InvitationModel, SQLUserRepository, SQLInvitationRepository, LoggingNotificationService, 4 auth use cases (register, login, create_invitation, validate_invitation). 79 new tests.