### PR TITLE
feat(rate-limit): sliding window rate limiting with Redis

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,7 +30,8 @@
         "**/.DS_Store": true,
         "**/Thumbs.db": true,
         "**/__pycache__": true,
-        "**/.ruff_cache": true
+        "**/.ruff_cache": true,
+        ".pytest_cache": true
     },
     "[jsonc]": {
         "editor.defaultFormatter": "vscode.json-language-features"

--- a/docs/API.md
+++ b/docs/API.md
@@ -737,7 +737,59 @@ curl -s -X DELETE http://localhost:8000/books/$BOOK_ID \
 
 ## Rate Limiting
 
-No hay rate limiting implementado en esta versión.
+La API aplica rate limiting per-IP usando Redis Sorted Sets (sliding window). Cada endpoint tiene su propio límite independiente.
+
+### Límites por endpoint
+
+| Endpoint | Límite | Ventana |
+|----------|--------|---------|
+| `POST /auth/login` | 5 requests | 60 segundos |
+| `POST /auth/register` | 3 requests | 60 segundos |
+| Todos los demás endpoints protegidos | 100 requests | 60 segundos |
+| `GET /health` | Sin límite | — |
+
+### Headers de respuesta
+
+Todas las respuestas incluyen headers del estándar IETF draft:
+
+| Header | Descripción |
+|--------|-------------|
+| `RateLimit-Limit` | Máximo de requests permitidos en la ventana |
+| `RateLimit-Remaining` | Requests restantes en la ventana actual |
+| `RateLimit-Reset` | Timestamp Unix de cuándo se reinicia la ventana |
+
+### Respuesta 429
+
+Cuando se excede el límite:
+
+```json
+{"detail": "Too many requests"}
+```
+
+Headers adicionales en 429:
+
+| Header | Descripción |
+|--------|-------------|
+| `Retry-After` | Segundos hasta que el cliente puede reintentar |
+
+### Configuración
+
+Los límites se configuran vía variables de entorno:
+
+| Variable | Default | Descripción |
+|----------|---------|-------------|
+| `RATE_LIMIT_ENABLED` | `true` | Habilitar/deshabilitar rate limiting |
+| `RATE_LIMIT_FAIL_OPEN` | `true` | Permitir tráfico si Redis no está disponible |
+| `RATE_LIMIT_LOGIN_MAX` | `5` | Máximo requests para login |
+| `RATE_LIMIT_LOGIN_WINDOW` | `60` | Ventana para login (segundos) |
+| `RATE_LIMIT_REGISTER_MAX` | `3` | Máximo requests para register |
+| `RATE_LIMIT_REGISTER_WINDOW` | `60` | Ventana para register (segundos) |
+| `RATE_LIMIT_GLOBAL_MAX` | `100` | Máximo requests para endpoints globales |
+| `RATE_LIMIT_GLOBAL_WINDOW` | `60` | Ventana para endpoints globales (segundos) |
+
+### Comportamiento fail-open
+
+Si Redis no está disponible, las requests pasan normalmente (fail-open). Rate limiting es calidad de servicio, no seguridad — la disponibilidad tiene prioridad.
 
 ---
 

--- a/docs/adr/ADR-008-rate-limit.md
+++ b/docs/adr/ADR-008-rate-limit.md
@@ -1,0 +1,42 @@
+# ADR-008: Rate Limiting per-IP con Redis Sorted Sets
+
+**Fecha**: 2026-05-05
+**Estado**: Aceptado
+
+## Contexto
+
+La API no tenía protección contra abuso: un atacante podía hacer brute-force a `/auth/login` sin restricciones. Se necesitaba rate limiting per-endpoint que fuera configurable, resiliente a fallos de Redis, y que siguiera la Clean Architecture del proyecto.
+
+Los requisitos clave:
+- Proteger endpoints de auth (`/login` 5 req/60s, `/register` 3 req/60s).
+- Rate limit global para el resto de endpoints (100 req/60s).
+- Eximir `/health` (usado por load balancers).
+- Fail-open: si Redis cae, el tráfico no se bloquea.
+- Headers IETF draft (`RateLimit-Limit`, `RateLimit-Remaining`, `RateLimit-Reset`, `Retry-After`).
+
+## Decisión
+
+Implementamos rate limiting per-endpoint vía dependencia FastAPI (`require_rate_limit()`), siguiendo el patrón de `require_permission()`:
+
+- **Algoritmo**: Sliding Window con Redis Sorted Sets. Pipeline atómico: `ZREMRANGEBYSCORE` → `ZCARD` → `ZADD` → `EXPIRE`. Evita el problema de burst-at-boundary de los fixed windows.
+- **Inyección**: `Depends(require_rate_limit(max, window))` en cada endpoint. Permite granularidad por-endpoint sin middleware global.
+- **Scope**: Per-IP, extraído de `X-Forwarded-For` (primer hop) o `request.client.host`.
+- **Fail-open**: `RedisRateLimiter.check()` captura todas las excepciones y retorna `True` con warning log. Rate limiting es QoS, no security boundary.
+- **NoOp fallback**: Cuando `RATE_LIMIT_ENABLED=False` o `DATABASE_URL=memory://`, se usa `NoOpRateLimiter` (sin Redis).
+- **Puerto abstracto**: `RateLimiter` ABC en `domain/rate_limiting/ports.py` con `check()` y `reset()`. El dominio no conoce Redis ni FastAPI.
+- **Headers**: Estándar IETF draft. Los 4 headers se setean en `_enforce_rate_limit()` y en el exception handler de `RateLimitExceededError`.
+
+## Alternativas consideradas
+
+- **Fixed Window (INCR + TTL)**: Más simple, pero vulnerable a burst-at-boundary. Un atacante puede hacer 5 requests al final de una ventana y 5 más al inicio de la siguiente = 10 en 2 segundos. Descartado.
+- **Token Bucket**: Más flexible para permitir bursts controlados. Más complejo de implementar con Redis. Overkill para el caso de uso actual. Descartado.
+- **Global middleware**: Un solo middleware para todos los endpoints. Pierde granularidad por-endpoint (login necesita 5/60s, books necesita 100/60s). Descartado.
+- **Per-user rate limiting**: Más preciso (un usuario con múltiples IPs no se ve limitado). Requiere cambios en el pipeline de auth. Diferido a futuro.
+
+## Consecuencias
+
+**Más fácil**: Configuración vía variables de entorno (`RATE_LIMIT_LOGIN_MAX`, etc.) — sin cambios de código para ajustar límites. Rollback instantáneo: `RATE_LIMIT_ENABLED=False` convierte todo en NoOp. Tests usan `fakeredis` y un `CountingRateLimiter` en memoria.
+
+**Más difícil**: `RateLimit-Remaining` es aproximado en respuestas exitosas (siempre muestra `max - 1` en lugar del conteo real). Corregir esto requeriría cambiar el ABC `RateLimiter.check()` de `bool` a un result object con `{allowed, remaining}` — se decidió no hacerlo en esta iteración para no romper la interfaz.
+
+**Riesgos**: Si Redis se llena de keys (más IPs concurrentes que TTL), el consumo de memoria crece. Mitigación: `EXPIRE` en cada key con `window_seconds` como TTL. Para un equipo interno, el volumen es despreciable.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,5 +11,6 @@
 | [ADR-005](ADR-005-python-313-minimum.md) | Python 3.13 como versión mínima | Aceptado |
 | [ADR-006](ADR-006-doble-validacion-pydantic-vos.md) | Doble validación (Pydantic + Domain VOs) | Aceptado |
 | [ADR-007](ADR-007-favorites-junction-table.md) | Favorites como junction table sin entidad de dominio | Aceptado |
+| [ADR-008](ADR-008-rate-limit.md) | Rate Limiting per-IP con Redis Sorted Sets | Aceptado |
 
 Formato: [Michael Nygard](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+    "fakeredis[lua]>=2.21",
     "pytest>=9.0.3",
     "pytest-asyncio>=0.24.0",
     "pytest-cov>=7.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "pyjwt>=2.8.0",
     "python-dotenv>=1.2.2",
     "sqlmodel>=0.0.22",
+    "redis[hiredis]>=5.0",
     "structlog>=24.0.0",
 ]
 

--- a/src/api/dependencies.py
+++ b/src/api/dependencies.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 from config.settings import AppSettings
@@ -34,6 +35,9 @@ from infrastructure.persistence.in_memory_favorite_repository import (
 from infrastructure.rate_limiting.noop_rate_limiter import NoOpRateLimiter
 from infrastructure.rate_limiting.redis_client import create_redis_client
 from infrastructure.rate_limiting.redis_rate_limiter import RedisRateLimiter
+
+if TYPE_CHECKING:
+    import redis.asyncio
 
 _settings: AppSettings | None = None
 

--- a/src/api/dependencies.py
+++ b/src/api/dependencies.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from urllib.parse import urlparse
+
 from config.settings import AppSettings
 from domain.auth.ports import (
     InvitationRepository,
@@ -12,6 +14,7 @@ from domain.auth.ports import (
 )
 from domain.collections.repositories import CollectionRepository
 from domain.favorites.repositories import FavoriteRepository
+from domain.rate_limiting.ports import RateLimiter
 from domain.repositories import BookRepository
 from infrastructure.auth.bcrypt_password_hasher import BcryptPasswordHasher
 from infrastructure.auth.in_memory_invitation_repository import (
@@ -28,6 +31,9 @@ from infrastructure.persistence.in_memory_collection_repository import (
 from infrastructure.persistence.in_memory_favorite_repository import (
     InMemoryFavoriteRepository,
 )
+from infrastructure.rate_limiting.noop_rate_limiter import NoOpRateLimiter
+from infrastructure.rate_limiting.redis_client import create_redis_client
+from infrastructure.rate_limiting.redis_rate_limiter import RedisRateLimiter
 
 _settings: AppSettings | None = None
 
@@ -38,6 +44,7 @@ _password_hasher: PasswordHasher | None = None
 _notification_service: NotificationService | None = None
 _collection_repo: CollectionRepository | None = None
 _favorite_repo: FavoriteRepository | None = None
+_rate_limiter: RateLimiter | None = None
 
 
 def get_settings() -> AppSettings:
@@ -142,11 +149,57 @@ def get_favorite_repo() -> FavoriteRepository:
     return _favorite_repo
 
 
+def get_redis_client(settings: AppSettings | None = None):
+    """Provide an async Redis client from application settings.
+
+    Args:
+        settings: Application settings. If None, uses get_settings().
+
+    Returns:
+        A ``redis.asyncio.Redis`` client instance.
+    """
+    if settings is None:
+        settings = get_settings()
+    return create_redis_client(settings)
+
+
+def get_rate_limiter() -> RateLimiter:
+    """Provide a RateLimiter implementation based on settings.
+
+    Resolution order:
+    1. ``RATE_LIMIT_ENABLED=False`` → NoOpRateLimiter
+    2. ``DATABASE_URL=memory://`` → NoOpRateLimiter
+    3. Otherwise → RedisRateLimiter
+
+    Returns:
+        A RateLimiter implementation (singleton).
+    """
+    global _rate_limiter
+    if _rate_limiter is not None:
+        return _rate_limiter
+
+    settings = get_settings()
+
+    if not settings.RATE_LIMIT_ENABLED:
+        _rate_limiter = NoOpRateLimiter()
+        return _rate_limiter
+
+    scheme = urlparse(settings.DATABASE_URL).scheme or "memory"
+    if scheme == "memory":
+        _rate_limiter = NoOpRateLimiter()
+        return _rate_limiter
+
+    redis_client = get_redis_client(settings)
+    _rate_limiter = RedisRateLimiter(redis_client)
+    return _rate_limiter
+
+
 def _reset_repos() -> None:
     """Reset all singleton repository instances.
 
     Called during test setup to ensure test isolation.
     """
-    global _collection_repo, _favorite_repo
+    global _collection_repo, _favorite_repo, _rate_limiter
     _collection_repo = None
     _favorite_repo = None
+    _rate_limiter = None

--- a/src/api/dependencies.py
+++ b/src/api/dependencies.py
@@ -149,17 +149,13 @@ def get_favorite_repo() -> FavoriteRepository:
     return _favorite_repo
 
 
-def get_redis_client(settings: AppSettings | None = None):
+def get_redis_client() -> redis.asyncio.Redis:
     """Provide an async Redis client from application settings.
-
-    Args:
-        settings: Application settings. If None, uses get_settings().
 
     Returns:
         A ``redis.asyncio.Redis`` client instance.
     """
-    if settings is None:
-        settings = get_settings()
+    settings = get_settings()
     return create_redis_client(settings)
 
 
@@ -189,7 +185,7 @@ def get_rate_limiter() -> RateLimiter:
         _rate_limiter = NoOpRateLimiter()
         return _rate_limiter
 
-    redis_client = get_redis_client(settings)
+    redis_client = get_redis_client()
     _rate_limiter = RedisRateLimiter(redis_client)
     return _rate_limiter
 

--- a/src/api/middleware/rate_limit.py
+++ b/src/api/middleware/rate_limit.py
@@ -1,0 +1,77 @@
+"""Rate limit middleware: dependency factory for per-endpoint rate limiting."""
+
+from __future__ import annotations
+
+import time
+
+from fastapi import Request
+from fastapi.responses import Response
+
+from api.dependencies import get_rate_limiter
+from domain.rate_limiting.exceptions import RateLimitExceededError
+
+
+def _extract_client_ip(request: Request) -> str:
+    """Extract the client IP from the request.
+
+    Uses ``X-Forwarded-For`` header (first entry) when behind a proxy,
+    falls back to ``request.client.host``.
+
+    Args:
+        request: The incoming FastAPI request.
+
+    Returns:
+        The client IP address as a string.
+    """
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    if request.client is not None:
+        return request.client.host
+    return "unknown"
+
+
+def require_rate_limit(max_requests: int, window_seconds: int):
+    """Create a FastAPI dependency that enforces rate limiting.
+
+    Mirrors the ``require_permission()`` pattern: returns an async dependency
+    function compatible with ``Depends()``.
+
+    Args:
+        max_requests: Maximum requests allowed in the window.
+        window_seconds: Duration of the sliding window in seconds.
+
+    Returns:
+        An async dependency function.
+    """
+
+    async def dependency(request: Request, response: Response) -> None:
+        """Check rate limit and set response headers.
+
+        Args:
+            request: The incoming HTTP request.
+            response: The outgoing HTTP response (for setting headers).
+
+        Raises:
+            RateLimitExceededError: If the client exceeds the rate limit.
+        """
+        limiter = get_rate_limiter()
+        client_ip = _extract_client_ip(request)
+        key = f"rate_limit:{client_ip}:{request.url.path}"
+        allowed = await limiter.check(
+            key=key,
+            max_requests=max_requests,
+            window_seconds=window_seconds,
+        )
+
+        # Set headers on every response
+        response.headers["RateLimit-Limit"] = str(max_requests)
+        response.headers["RateLimit-Reset"] = str(int(time.time()) + window_seconds)
+
+        if not allowed:
+            response.headers["RateLimit-Remaining"] = "0"
+            raise RateLimitExceededError(retry_after=window_seconds)
+
+        response.headers["RateLimit-Remaining"] = str(max_requests - 1)
+
+    return dependency

--- a/src/api/middleware/rate_limit.py
+++ b/src/api/middleware/rate_limit.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import time
 
-from fastapi import Request
+from fastapi import Depends, Request
 from fastapi.responses import Response
 
-from api.dependencies import get_rate_limiter
+from api.dependencies import get_rate_limiter, get_settings
+from config.settings import AppSettings
 from domain.rate_limiting.exceptions import RateLimitExceededError
+from domain.rate_limiting.ports import RateLimiter
 
 
 def _extract_client_ip(request: Request) -> str:
@@ -31,6 +33,46 @@ def _extract_client_ip(request: Request) -> str:
     return "unknown"
 
 
+async def _enforce_rate_limit(
+    request: Request,
+    response: Response,
+    limiter: RateLimiter,
+    max_requests: int,
+    window_seconds: int,
+) -> None:
+    """Core rate limit enforcement logic.
+
+    Args:
+        request: The incoming HTTP request.
+        response: The outgoing HTTP response.
+        limiter: The rate limiter implementation.
+        max_requests: Maximum requests allowed in the window.
+        window_seconds: Duration of the sliding window in seconds.
+
+    Raises:
+        RateLimitExceededError: If the client exceeds the rate limit.
+    """
+    client_ip = _extract_client_ip(request)
+    key = f"rate_limit:{client_ip}:{request.url.path}"
+    allowed = await limiter.check(
+        key=key,
+        max_requests=max_requests,
+        window_seconds=window_seconds,
+    )
+
+    response.headers["RateLimit-Limit"] = str(max_requests)
+    response.headers["RateLimit-Reset"] = str(int(time.time()) + window_seconds)
+
+    if not allowed:
+        response.headers["RateLimit-Remaining"] = "0"
+        raise RateLimitExceededError(
+            retry_after=window_seconds,
+            limit=max_requests,
+        )
+
+    response.headers["RateLimit-Remaining"] = str(max_requests - 1)
+
+
 def require_rate_limit(max_requests: int, window_seconds: int):
     """Create a FastAPI dependency that enforces rate limiting.
 
@@ -45,33 +87,99 @@ def require_rate_limit(max_requests: int, window_seconds: int):
         An async dependency function.
     """
 
-    async def dependency(request: Request, response: Response) -> None:
+    async def dependency(
+        request: Request,
+        response: Response,
+        limiter: RateLimiter = Depends(get_rate_limiter),
+    ) -> None:
         """Check rate limit and set response headers.
 
         Args:
             request: The incoming HTTP request.
             response: The outgoing HTTP response (for setting headers).
+            limiter: Rate limiter implementation (injected by FastAPI).
 
         Raises:
             RateLimitExceededError: If the client exceeds the rate limit.
         """
-        limiter = get_rate_limiter()
-        client_ip = _extract_client_ip(request)
-        key = f"rate_limit:{client_ip}:{request.url.path}"
-        allowed = await limiter.check(
-            key=key,
-            max_requests=max_requests,
-            window_seconds=window_seconds,
-        )
-
-        # Set headers on every response
-        response.headers["RateLimit-Limit"] = str(max_requests)
-        response.headers["RateLimit-Reset"] = str(int(time.time()) + window_seconds)
-
-        if not allowed:
-            response.headers["RateLimit-Remaining"] = "0"
-            raise RateLimitExceededError(retry_after=window_seconds)
-
-        response.headers["RateLimit-Remaining"] = str(max_requests - 1)
+        await _enforce_rate_limit(request, response, limiter, max_requests, window_seconds)
 
     return dependency
+
+
+async def login_rate_limit(
+    request: Request,
+    response: Response,
+    settings: AppSettings = Depends(get_settings),
+    limiter: RateLimiter = Depends(get_rate_limiter),
+) -> None:
+    """Rate limit dependency for POST /auth/login.
+
+    Reads limits from application settings.
+
+    Args:
+        request: The incoming HTTP request.
+        response: The outgoing HTTP response.
+        settings: Application settings.
+        limiter: Rate limiter implementation.
+
+    Raises:
+        RateLimitExceededError: If the client exceeds the rate limit.
+    """
+    await _enforce_rate_limit(
+        request, response, limiter,
+        settings.RATE_LIMIT_LOGIN_MAX,
+        settings.RATE_LIMIT_LOGIN_WINDOW,
+    )
+
+
+async def register_rate_limit(
+    request: Request,
+    response: Response,
+    settings: AppSettings = Depends(get_settings),
+    limiter: RateLimiter = Depends(get_rate_limiter),
+) -> None:
+    """Rate limit dependency for POST /auth/register.
+
+    Reads limits from application settings.
+
+    Args:
+        request: The incoming HTTP request.
+        response: The outgoing HTTP response.
+        settings: Application settings.
+        limiter: Rate limiter implementation.
+
+    Raises:
+        RateLimitExceededError: If the client exceeds the rate limit.
+    """
+    await _enforce_rate_limit(
+        request, response, limiter,
+        settings.RATE_LIMIT_REGISTER_MAX,
+        settings.RATE_LIMIT_REGISTER_WINDOW,
+    )
+
+
+async def global_rate_limit(
+    request: Request,
+    response: Response,
+    settings: AppSettings = Depends(get_settings),
+    limiter: RateLimiter = Depends(get_rate_limiter),
+) -> None:
+    """Rate limit dependency for global endpoint rate limiting.
+
+    Reads limits from application settings.
+
+    Args:
+        request: The incoming HTTP request.
+        response: The outgoing HTTP response.
+        settings: Application settings.
+        limiter: Rate limiter implementation.
+
+    Raises:
+        RateLimitExceededError: If the client exceeds the rate limit.
+    """
+    await _enforce_rate_limit(
+        request, response, limiter,
+        settings.RATE_LIMIT_GLOBAL_MAX,
+        settings.RATE_LIMIT_GLOBAL_WINDOW,
+    )

--- a/src/api/routers/auth.py
+++ b/src/api/routers/auth.py
@@ -15,6 +15,7 @@ from api.dependencies import (
     get_user_repo,
 )
 from api.middleware.auth import require_permission
+from api.middleware.rate_limit import login_rate_limit, register_rate_limit
 from application.use_cases.auth.create_invitation import create_invitation
 from application.use_cases.auth.login_user import login_user
 from application.use_cases.auth.register_user import register_user
@@ -65,6 +66,7 @@ async def register_endpoint(
     user_repo: Annotated[UserRepository, Depends(get_user_repo)],
     hasher: Annotated[PasswordHasher, Depends(get_password_hasher)],
     invitation_repo: Annotated[InvitationRepository, Depends(get_invitation_repo)],
+    _rate_limit: None = Depends(register_rate_limit),
 ):
     """Register a new user.
 
@@ -108,6 +110,7 @@ async def login_endpoint(
     user_repo: Annotated[UserRepository, Depends(get_user_repo)],
     hasher: Annotated[PasswordHasher, Depends(get_password_hasher)],
     token_service: Annotated[TokenService, Depends(get_token_service)],
+    _rate_limit: None = Depends(login_rate_limit),
 ):
     """Authenticate a user and return a JWT.
 

--- a/src/api/routers/books.py
+++ b/src/api/routers/books.py
@@ -14,6 +14,7 @@ from fastapi.responses import Response
 from api.dependencies import get_book_repo
 from api.mappers import book_to_dict
 from api.middleware.auth import require_permission
+from api.middleware.rate_limit import global_rate_limit
 from api.schemas import BookPayload
 from application.use_cases.create_book import create_book
 from application.use_cases.delete_book import delete_book
@@ -33,6 +34,7 @@ async def list_books_endpoint(
     limit: Annotated[int, Query(ge=1, le=100)] = 20,
     offset: Annotated[int, Query(ge=0)] = 0,
     user: dict = Depends(require_permission(Operation.BOOK_READ)),
+    _rate_limit: None = Depends(global_rate_limit),
 ):
     """List books with pagination.
 
@@ -50,6 +52,7 @@ async def get_book_endpoint(
     book_id: str,
     repo: Annotated[BookRepository, Depends(get_book_repo)],
     user: dict = Depends(require_permission(Operation.BOOK_READ)),
+    _rate_limit: None = Depends(global_rate_limit),
 ):
     """Get a book by id."""
     book = await get_book(repo, book_id)
@@ -63,6 +66,7 @@ async def get_books_by_name_endpoint(
     name: str,
     repo: Annotated[BookRepository, Depends(get_book_repo)],
     user: dict = Depends(require_permission(Operation.BOOK_READ)),
+    _rate_limit: None = Depends(global_rate_limit),
 ):
     """Search books by name (case-insensitive substring match)."""
     return [book_to_dict(b) for b in await get_books_by_name(repo, name)]
@@ -73,6 +77,7 @@ async def create_book_endpoint(
     book: BookPayload,
     repo: Annotated[BookRepository, Depends(get_book_repo)],
     user: dict = Depends(require_permission(Operation.BOOK_CREATE)),
+    _rate_limit: None = Depends(global_rate_limit),
 ):
     """Create a book."""
     created = await create_book(
@@ -92,6 +97,7 @@ async def replace_book_endpoint(
     book: BookPayload,
     repo: Annotated[BookRepository, Depends(get_book_repo)],
     user: dict = Depends(require_permission(Operation.BOOK_UPDATE)),
+    _rate_limit: None = Depends(global_rate_limit),
 ):
     """Replace a book (PUT semantics)."""
     updated = await replace_book(
@@ -113,6 +119,7 @@ async def delete_book_endpoint(
     book_id: str,
     repo: Annotated[BookRepository, Depends(get_book_repo)],
     user: dict = Depends(require_permission(Operation.BOOK_DELETE)),
+    _rate_limit: None = Depends(global_rate_limit),
 ):
     """Delete a book."""
     existing = await get_book(repo, book_id)

--- a/src/api/routers/collections.py
+++ b/src/api/routers/collections.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel
 
 from api.dependencies import get_collection_repo
 from api.middleware.auth import require_permission
+from api.middleware.rate_limit import global_rate_limit
 from application.use_cases.collections.create_collection import create_collection
 from application.use_cases.collections.delete_collection import delete_collection
 from application.use_cases.collections.list_collections import list_collections
@@ -48,6 +49,7 @@ async def create_collection_endpoint(
     payload: CollectionPayload,
     repo: Annotated[CollectionRepository, Depends(get_collection_repo)],
     user: dict = Depends(require_permission(Operation.COLLECTION_CREATE)),
+    _rate_limit: None = Depends(global_rate_limit),
 ):
     """Create a new collection owned by the authenticated user.
 
@@ -69,6 +71,7 @@ async def create_collection_endpoint(
 async def list_collections_endpoint(
     repo: Annotated[CollectionRepository, Depends(get_collection_repo)],
     user: dict = Depends(require_permission(Operation.COLLECTION_READ)),
+    _rate_limit: None = Depends(global_rate_limit),
 ):
     """List collections visible to the authenticated user.
 
@@ -90,6 +93,7 @@ async def delete_collection_endpoint(
     collection_id: str,
     repo: Annotated[CollectionRepository, Depends(get_collection_repo)],
     user: dict = Depends(require_permission(Operation.COLLECTION_DELETE)),
+    _rate_limit: None = Depends(global_rate_limit),
 ):
     """Delete a collection. Owner or admin only.
 

--- a/src/api/routers/favorites.py
+++ b/src/api/routers/favorites.py
@@ -12,6 +12,7 @@ from fastapi.responses import Response
 
 from api.dependencies import get_favorite_repo
 from api.middleware.auth import require_permission
+from api.middleware.rate_limit import global_rate_limit
 from application.use_cases.favorites.add_favorite import add_favorite
 from application.use_cases.favorites.list_favorites import list_favorites
 from application.use_cases.favorites.remove_favorite import remove_favorite
@@ -26,6 +27,7 @@ async def add_favorite_endpoint(
     book_id: str,
     repo: Annotated[FavoriteRepository, Depends(get_favorite_repo)],
     user: dict = Depends(require_permission(Operation.FAVORITE_ADD)),
+    _rate_limit: None = Depends(global_rate_limit),
 ):
     """Add a book to the user's favorites (idempotent).
 
@@ -43,6 +45,7 @@ async def remove_favorite_endpoint(
     book_id: str,
     repo: Annotated[FavoriteRepository, Depends(get_favorite_repo)],
     user: dict = Depends(require_permission(Operation.FAVORITE_REMOVE)),
+    _rate_limit: None = Depends(global_rate_limit),
 ):
     """Remove a book from the user's favorites (idempotent).
 
@@ -59,6 +62,7 @@ async def remove_favorite_endpoint(
 async def list_favorites_endpoint(
     repo: Annotated[FavoriteRepository, Depends(get_favorite_repo)],
     user: dict = Depends(require_permission(Operation.COLLECTION_READ)),
+    _rate_limit: None = Depends(global_rate_limit),
 ):
     """List the user's favorite book IDs in reverse chronological order.
 

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -39,6 +39,31 @@ class AppSettings(BaseSettings):
     LOG_LEVEL: str = "INFO"
     ENV: str = "development"
 
+    # --- Rate Limiting ---
+    RATE_LIMIT_ENABLED: bool = True
+    """Master switch for rate limiting. When False, all requests pass through (NoOp)."""
+
+    RATE_LIMIT_FAIL_OPEN: bool = True
+    """Allow requests when Redis is unreachable (fail-open for availability)."""
+
+    RATE_LIMIT_LOGIN_MAX: int = 5
+    """Maximum login requests per IP within the login window."""
+
+    RATE_LIMIT_LOGIN_WINDOW: int = 60
+    """Login rate limit window in seconds."""
+
+    RATE_LIMIT_REGISTER_MAX: int = 3
+    """Maximum register requests per IP within the register window."""
+
+    RATE_LIMIT_REGISTER_WINDOW: int = 60
+    """Register rate limit window in seconds."""
+
+    RATE_LIMIT_GLOBAL_MAX: int = 100
+    """Default maximum requests per IP for unspecified endpoints."""
+
+    RATE_LIMIT_GLOBAL_WINDOW: int = 60
+    """Default rate limit window in seconds for unspecified endpoints."""
+
     @field_validator("SECRET_KEY")
     @classmethod
     def secret_key_min_length(cls, v: str) -> str:

--- a/src/domain/rate_limiting/__init__.py
+++ b/src/domain/rate_limiting/__init__.py
@@ -1,5 +1,8 @@
 """Rate limiting domain package: ports and exceptions."""
 
+from __future__ import annotations
+
+from domain.rate_limiting.exceptions import RateLimitExceededError
 from domain.rate_limiting.ports import RateLimiter
 
-__all__ = ["RateLimiter"]
+__all__ = ["RateLimiter", "RateLimitExceededError"]

--- a/src/domain/rate_limiting/__init__.py
+++ b/src/domain/rate_limiting/__init__.py
@@ -1,0 +1,5 @@
+"""Rate limiting domain package: ports and exceptions."""
+
+from domain.rate_limiting.ports import RateLimiter
+
+__all__ = ["RateLimiter"]

--- a/src/domain/rate_limiting/exceptions.py
+++ b/src/domain/rate_limiting/exceptions.py
@@ -23,14 +23,16 @@ class RateLimitExceededError(DomainError):
 
     Attributes:
         retry_after: Seconds until the client may retry the request.
+        limit: Maximum requests allowed in the window (for response headers).
     """
 
     retry_after: int
+    limit: int
 
     def __str__(self) -> str:
         """Return a readable string representation."""
         return f"Rate limit exceeded. Retry after {self.retry_after} seconds."
 
     def __hash__(self) -> int:
-        """Make RateLimitExceededError hashable based on retry_after."""
-        return hash(self.retry_after)
+        """Make RateLimitExceededError hashable based on fields."""
+        return hash((self.retry_after, self.limit))

--- a/src/domain/rate_limiting/exceptions.py
+++ b/src/domain/rate_limiting/exceptions.py
@@ -1,0 +1,36 @@
+"""Rate limiting domain exceptions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from domain.exceptions import DomainError
+
+
+@dataclass(eq=True)
+class RateLimitExceeded(DomainError):
+    """Raised when a client exceeds the rate limit for an endpoint.
+
+    PERMANENT CONSTRAINT — NOT frozen:
+    Python 3.14+ frozen dataclasses disallow ``__setattr__`` entirely, but
+    ``Exception`` needs to set ``__traceback__`` during propagation at the C
+    level. Using ``frozen=True`` on an Exception subclass causes a runtime
+    ``AttributeError`` when the exception is raised.
+
+    This class uses ``eq=True`` plus a manual ``__hash__`` to achieve the same
+    value semantics (hashable, comparable by field values) without blocking
+    ``Exception`` internals.
+
+    Attributes:
+        retry_after: Seconds until the client may retry the request.
+    """
+
+    retry_after: int
+
+    def __str__(self) -> str:
+        """Return a readable string representation."""
+        return f"Rate limit exceeded. Retry after {self.retry_after} seconds."
+
+    def __hash__(self) -> int:
+        """Make RateLimitExceeded hashable based on retry_after."""
+        return hash(self.retry_after)

--- a/src/domain/rate_limiting/exceptions.py
+++ b/src/domain/rate_limiting/exceptions.py
@@ -8,7 +8,7 @@ from domain.exceptions import DomainError
 
 
 @dataclass(eq=True)
-class RateLimitExceeded(DomainError):
+class RateLimitExceededError(DomainError):
     """Raised when a client exceeds the rate limit for an endpoint.
 
     PERMANENT CONSTRAINT — NOT frozen:
@@ -32,5 +32,5 @@ class RateLimitExceeded(DomainError):
         return f"Rate limit exceeded. Retry after {self.retry_after} seconds."
 
     def __hash__(self) -> int:
-        """Make RateLimitExceeded hashable based on retry_after."""
+        """Make RateLimitExceededError hashable based on retry_after."""
         return hash(self.retry_after)

--- a/src/domain/rate_limiting/ports.py
+++ b/src/domain/rate_limiting/ports.py
@@ -1,0 +1,34 @@
+"""Rate limiting domain ports: abstract interfaces for rate limit adapters."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class RateLimiter(ABC):
+    """Port for rate limiting operations.
+
+    Implementations may use Redis Sorted Sets (sliding window),
+    in-memory counters, or no-ops for testing/fail-open.
+    """
+
+    @abstractmethod
+    async def check(self, key: str, max_requests: int, window_seconds: int) -> bool:
+        """Check if a request is allowed under the rate limit.
+
+        Args:
+            key: Unique identifier for the rate limit scope (e.g., IP + path).
+            max_requests: Maximum requests allowed in the window.
+            window_seconds: Duration of the sliding window in seconds.
+
+        Returns:
+            True if the request is allowed, False if the limit is exceeded.
+        """
+
+    @abstractmethod
+    async def reset(self, key: str) -> None:
+        """Reset the rate limit counter for a given key.
+
+        Args:
+            key: The rate limit key to reset.
+        """

--- a/src/infrastructure/rate_limiting/__init__.py
+++ b/src/infrastructure/rate_limiting/__init__.py
@@ -1,0 +1,7 @@
+"""Infrastructure rate limiting package: adapters for domain rate limiter port."""
+
+from __future__ import annotations
+
+from infrastructure.rate_limiting.noop_rate_limiter import NoOpRateLimiter
+
+__all__ = ["NoOpRateLimiter"]

--- a/src/infrastructure/rate_limiting/__init__.py
+++ b/src/infrastructure/rate_limiting/__init__.py
@@ -3,5 +3,6 @@
 from __future__ import annotations
 
 from infrastructure.rate_limiting.noop_rate_limiter import NoOpRateLimiter
+from infrastructure.rate_limiting.redis_rate_limiter import RedisRateLimiter
 
-__all__ = ["NoOpRateLimiter"]
+__all__ = ["NoOpRateLimiter", "RedisRateLimiter"]

--- a/src/infrastructure/rate_limiting/noop_rate_limiter.py
+++ b/src/infrastructure/rate_limiting/noop_rate_limiter.py
@@ -1,0 +1,33 @@
+"""NoOp rate limiter: always allows requests (fail-open / testing fallback)."""
+
+from __future__ import annotations
+
+from domain.rate_limiting.ports import RateLimiter
+
+
+class NoOpRateLimiter(RateLimiter):
+    """Rate limiter that always allows requests.
+
+    Used as a fallback when Redis is unavailable or rate limiting is disabled
+    (``RATE_LIMIT_ENABLED=False`` or ``DATABASE_URL=memory://``).
+    """
+
+    async def check(self, key: str, max_requests: int, window_seconds: int) -> bool:
+        """Always allow the request.
+
+        Args:
+            key: Rate limit key (ignored).
+            max_requests: Maximum requests (ignored).
+            window_seconds: Window duration (ignored).
+
+        Returns:
+            Always True.
+        """
+        return True
+
+    async def reset(self, key: str) -> None:
+        """No-op reset.
+
+        Args:
+            key: Rate limit key (ignored).
+        """

--- a/src/infrastructure/rate_limiting/redis_client.py
+++ b/src/infrastructure/rate_limiting/redis_client.py
@@ -1,0 +1,19 @@
+"""Redis client factory for rate limiting."""
+
+from __future__ import annotations
+
+import redis.asyncio
+
+from config.settings import AppSettings
+
+
+def create_redis_client(settings: AppSettings) -> redis.asyncio.Redis:
+    """Create an async Redis client from application settings.
+
+    Args:
+        settings: Application settings containing ``REDIS_URL``.
+
+    Returns:
+        A connected ``redis.asyncio.Redis`` client.
+    """
+    return redis.asyncio.Redis.from_url(settings.REDIS_URL)

--- a/src/infrastructure/rate_limiting/redis_rate_limiter.py
+++ b/src/infrastructure/rate_limiting/redis_rate_limiter.py
@@ -1,0 +1,78 @@
+"""Redis-backed rate limiter using sorted sets for sliding window counting."""
+
+from __future__ import annotations
+
+import time
+
+import structlog
+
+from domain.rate_limiting.ports import RateLimiter
+
+logger = structlog.get_logger(__name__)
+
+
+class RedisRateLimiter(RateLimiter):
+    """Sliding window rate limiter backed by Redis Sorted Sets.
+
+    Uses an atomic pipeline: ZREMRANGEBYSCORE → ZCARD → ZADD → EXPIRE.
+    Fail-open on Redis errors: returns True and logs a warning.
+    """
+
+    def __init__(self, redis_client) -> None:
+        """Initialize with an async Redis client.
+
+        Args:
+            redis_client: A ``redis.asyncio.Redis`` (or compatible) instance.
+        """
+        self._redis = redis_client
+
+    async def check(self, key: str, max_requests: int, window_seconds: int) -> bool:
+        """Check if a request is allowed using a sliding window.
+
+        Args:
+            key: Unique identifier for the rate limit scope.
+            max_requests: Maximum requests allowed in the window.
+            window_seconds: Duration of the sliding window in seconds.
+
+        Returns:
+            True if allowed, False if limit exceeded. Fail-open on errors.
+        """
+        try:
+            now = time.time()
+            window_start = now - window_seconds
+
+            pipe = self._redis.pipeline(transaction=True)
+            pipe.zremrangebyscore(key, 0, window_start)
+            pipe.zcard(key)
+            pipe.zadd(key, {f"{now}": now})
+            pipe.expire(key, window_seconds)
+            results = await pipe.execute()
+
+            current_count = results[1]
+            if current_count >= max_requests:
+                # Remove the entry we just added — it was over the limit
+                await self._redis.zrem(key, f"{now}")
+                return False
+            return True
+        except Exception:
+            logger.warning(
+                "rate_limiter_unavailable",
+                message="Rate limiter unavailable, allowing request",
+                key=key,
+            )
+            return True
+
+    async def reset(self, key: str) -> None:
+        """Reset the rate limit counter for a given key.
+
+        Args:
+            key: The rate limit key to reset.
+        """
+        try:
+            await self._redis.delete(key)
+        except Exception:
+            logger.warning(
+                "rate_limiter_reset_failed",
+                message="Failed to reset rate limiter key",
+                key=key,
+            )

--- a/src/main.py
+++ b/src/main.py
@@ -28,6 +28,7 @@ from domain.auth.exceptions import (
     UserAlreadyExists,
 )
 from domain.exceptions import AggregatedValidationError, DomainError, ValidationError
+from domain.rate_limiting.exceptions import RateLimitExceededError
 from infrastructure.json_book_repository import JsonBookRepository
 from infrastructure.memory_book_repository import InMemoryBookRepository
 from infrastructure.repository_factory import create_repository
@@ -234,6 +235,24 @@ def create_app(settings: AppSettings | None = None) -> FastAPI:
             path=request.url.path,
         )
         return JSONResponse(status_code=409, content={"detail": str(exc)})
+
+    @app.exception_handler(RateLimitExceededError)
+    async def rate_limit_handler(
+        request: Request, exc: RateLimitExceededError
+    ) -> JSONResponse:
+        """Convert RateLimitExceededError to HTTP 429."""
+        logger.warning(
+            "rate_limit_exceeded",
+            exception_type=type(exc).__name__,
+            message=str(exc),
+            path=request.url.path,
+            retry_after=exc.retry_after,
+        )
+        return JSONResponse(
+            status_code=429,
+            content={"detail": "Too many requests"},
+            headers={"Retry-After": str(exc.retry_after)},
+        )
 
     @app.get("/")
     def root():

--- a/src/main.py
+++ b/src/main.py
@@ -6,6 +6,7 @@ to application use cases and persistence to infrastructure adapters.
 
 from __future__ import annotations
 
+import time
 from contextlib import asynccontextmanager
 from urllib.parse import urlparse
 
@@ -251,7 +252,12 @@ def create_app(settings: AppSettings | None = None) -> FastAPI:
         return JSONResponse(
             status_code=429,
             content={"detail": "Too many requests"},
-            headers={"Retry-After": str(exc.retry_after)},
+            headers={
+                "Retry-After": str(exc.retry_after),
+                "RateLimit-Limit": str(exc.limit),
+                "RateLimit-Remaining": "0",
+                "RateLimit-Reset": str(int(time.time()) + exc.retry_after),
+            },
         )
 
     @app.get("/")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,9 +9,10 @@ from __future__ import annotations
 import pytest
 from fastapi.testclient import TestClient
 
-from api.dependencies import _reset_repos
+from api.dependencies import _reset_repos, get_rate_limiter
 from config.settings import AppSettings
 from infrastructure.auth.jwt_token_service import JwtTokenService
+from infrastructure.rate_limiting.noop_rate_limiter import NoOpRateLimiter
 from main import create_app
 
 TEST_SECRET_KEY = "test-secret-key-at-least-32-chars-long"
@@ -59,7 +60,9 @@ def client(test_settings: AppSettings) -> TestClient:
         Configured TestClient instance.
     """
     _reset_repos()
-    return TestClient(create_app(test_settings))
+    app = create_app(test_settings)
+    app.dependency_overrides[get_rate_limiter] = lambda: NoOpRateLimiter()
+    return TestClient(app)
 
 
 @pytest.fixture

--- a/tests/integration/test_auth_api.py
+++ b/tests/integration/test_auth_api.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from fastapi.testclient import TestClient
 
+from api.dependencies import get_rate_limiter
 from config.settings import AppSettings
 from infrastructure.auth.jwt_token_service import JwtTokenService
+from infrastructure.rate_limiting.noop_rate_limiter import NoOpRateLimiter
 from main import create_app
 
 TEST_SECRET = "test-secret-key-at-least-32-chars-long"
@@ -25,7 +27,9 @@ def _client(test_settings: AppSettings | None = None) -> TestClient:
             DATABASE_URL="memory://",
             SECRET_KEY=TEST_SECRET,
         )
-    return TestClient(create_app(test_settings))
+    app = create_app(test_settings)
+    app.dependency_overrides[get_rate_limiter] = lambda: NoOpRateLimiter()
+    return TestClient(app)
 
 
 def _admin_headers(test_settings: AppSettings) -> dict[str, str]:

--- a/tests/integration/test_books_api.py
+++ b/tests/integration/test_books_api.py
@@ -8,8 +8,10 @@ from __future__ import annotations
 
 from fastapi.testclient import TestClient
 
+from api.dependencies import get_rate_limiter
 from config.settings import AppSettings
 from infrastructure.auth.jwt_token_service import JwtTokenService
+from infrastructure.rate_limiting.noop_rate_limiter import NoOpRateLimiter
 from main import create_app
 
 TEST_SECRET = "test-secret-key-at-least-32-chars-long"
@@ -30,7 +32,9 @@ def _client() -> TestClient:
     Returns:
         Configured TestClient instance.
     """
-    return TestClient(create_app(_settings()))
+    app = create_app(_settings())
+    app.dependency_overrides[get_rate_limiter] = lambda: NoOpRateLimiter()
+    return TestClient(app)
 
 
 def _auth_headers() -> dict[str, str]:

--- a/tests/integration/test_collections_api.py
+++ b/tests/integration/test_collections_api.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 from fastapi.testclient import TestClient
 
-from api.dependencies import _reset_repos
+from api.dependencies import _reset_repos, get_rate_limiter
 from config.settings import AppSettings
 from infrastructure.auth.jwt_token_service import JwtTokenService
+from infrastructure.rate_limiting.noop_rate_limiter import NoOpRateLimiter
 from main import create_app
 
 TEST_SECRET = "test-secret-key-at-least-32-chars-long"
@@ -20,7 +21,9 @@ def _settings() -> AppSettings:
 def _client() -> TestClient:
     """Create a TestClient with in-memory repository."""
     _reset_repos()
-    return TestClient(create_app(_settings()))
+    app = create_app(_settings())
+    app.dependency_overrides[get_rate_limiter] = lambda: NoOpRateLimiter()
+    return TestClient(app)
 
 
 def _user_headers(user_id: str = "test-user-id") -> dict[str, str]:

--- a/tests/integration/test_favorites_api.py
+++ b/tests/integration/test_favorites_api.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 from fastapi.testclient import TestClient
 
-from api.dependencies import _reset_repos
+from api.dependencies import _reset_repos, get_rate_limiter
 from config.settings import AppSettings
 from infrastructure.auth.jwt_token_service import JwtTokenService
+from infrastructure.rate_limiting.noop_rate_limiter import NoOpRateLimiter
 from main import create_app
 
 TEST_SECRET = "test-secret-key-at-least-32-chars-long"
@@ -20,7 +21,9 @@ def _settings() -> AppSettings:
 def _client() -> TestClient:
     """Create a TestClient with in-memory repository."""
     _reset_repos()
-    return TestClient(create_app(_settings()))
+    app = create_app(_settings())
+    app.dependency_overrides[get_rate_limiter] = lambda: NoOpRateLimiter()
+    return TestClient(app)
 
 
 def _user_headers(user_id: str = "test-user-id") -> dict[str, str]:

--- a/tests/integration/test_health.py
+++ b/tests/integration/test_health.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from fastapi.testclient import TestClient
 
-from api.dependencies import get_book_repo
+from api.dependencies import get_book_repo, get_rate_limiter
 from config.settings import AppSettings
+from infrastructure.rate_limiting.noop_rate_limiter import NoOpRateLimiter
 from main import create_app
 
 
@@ -15,6 +16,7 @@ class TestHealthEndpoint:
     def test_health_returns_200_ok(self) -> None:
         """GET /health returns 200 with status ok when DB is reachable."""
         app = create_app(AppSettings(DATABASE_URL="memory://"))
+        app.dependency_overrides[get_rate_limiter] = lambda: NoOpRateLimiter()
         client = TestClient(app)
         resp = client.get("/health")
         assert resp.status_code == 200
@@ -25,6 +27,7 @@ class TestHealthEndpoint:
     def test_health_does_not_require_auth(self) -> None:
         """GET /health is accessible without Authorization header."""
         app = create_app(AppSettings(DATABASE_URL="memory://"))
+        app.dependency_overrides[get_rate_limiter] = lambda: NoOpRateLimiter()
         client = TestClient(app)
         resp = client.get("/health")
         assert resp.status_code == 200

--- a/tests/integration/test_rate_limit.py
+++ b/tests/integration/test_rate_limit.py
@@ -1,0 +1,377 @@
+"""T14/T16/T18: Integration tests for rate limiting behavior.
+
+Tests real rate limiting with TestClient using a counting rate limiter
+to verify 429 responses, headers, fail-open, and key isolation.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+from fastapi.testclient import TestClient
+
+from api.dependencies import get_rate_limiter
+from config.settings import AppSettings
+from domain.rate_limiting.ports import RateLimiter
+from infrastructure.auth.jwt_token_service import JwtTokenService
+from infrastructure.rate_limiting.redis_rate_limiter import RedisRateLimiter
+from main import create_app
+
+TEST_SECRET = "test-secret-key-at-least-32-chars-long"
+
+
+class CountingRateLimiter(RateLimiter):
+    """Rate limiter that tracks requests per key using in-memory counters.
+
+    Simulates sliding window behavior for integration testing without Redis.
+    """
+
+    def __init__(self) -> None:
+        """Initialize with empty counters."""
+        self._counts: dict[str, list[float]] = {}
+
+    async def check(self, key: str, max_requests: int, window_seconds: int) -> bool:
+        """Check if request is allowed using in-memory sliding window.
+
+        Args:
+            key: Rate limit key.
+            max_requests: Maximum requests in window.
+            window_seconds: Window duration in seconds.
+
+        Returns:
+            True if allowed, False if limit exceeded.
+        """
+        now = time.time()
+        window_start = now - window_seconds
+
+        # Clean expired entries
+        if key in self._counts:
+            self._counts[key] = [t for t in self._counts[key] if t > window_start]
+        else:
+            self._counts[key] = []
+
+        if len(self._counts[key]) >= max_requests:
+            return False
+
+        self._counts[key].append(now)
+        return True
+
+    async def reset(self, key: str) -> None:
+        """Reset counter for a key.
+
+        Args:
+            key: Rate limit key to reset.
+        """
+        self._counts.pop(key, None)
+
+
+def _auth_headers() -> dict[str, str]:
+    """Create Authorization headers for a standard test user."""
+    token_service = JwtTokenService(TEST_SECRET)
+    token = token_service.generate("test-user-id", "user")
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _client_with_limiter(
+    limiter: RateLimiter,
+    settings: AppSettings | None = None,
+) -> TestClient:
+    """Create a TestClient with a specific rate limiter override.
+
+    Args:
+        limiter: The rate limiter to use.
+        settings: Optional settings override.
+
+    Returns:
+        Configured TestClient instance.
+    """
+    if settings is None:
+        settings = AppSettings(
+            DATABASE_URL="memory://",
+            SECRET_KEY=TEST_SECRET,
+            RATE_LIMIT_ENABLED=True,
+        )
+    app = create_app(settings)
+    app.dependency_overrides[get_rate_limiter] = lambda: limiter
+    return TestClient(app)
+
+
+def _broken_limiter() -> RedisRateLimiter:
+    """Create a RedisRateLimiter with broken Redis (fail-open test).
+
+    The fail-open logic lives inside RedisRateLimiter.check() which catches
+    all exceptions. We need a real RedisRateLimiter with a broken backend.
+    """
+    broken_redis = MagicMock()
+    broken_redis.pipeline = MagicMock()
+    mock_pipe = MagicMock()
+    mock_pipe.zremrangebyscore = MagicMock(return_value=mock_pipe)
+    mock_pipe.zcard = MagicMock(return_value=mock_pipe)
+    mock_pipe.zadd = MagicMock(return_value=mock_pipe)
+    mock_pipe.expire = MagicMock(return_value=mock_pipe)
+    mock_pipe.execute = AsyncMock(side_effect=ConnectionError("Connection refused"))
+    broken_redis.pipeline.return_value = mock_pipe
+    return RedisRateLimiter(broken_redis)
+
+
+class TestRateLimit429:
+    """T14: Test that rate-limited endpoints return 429 when over limit."""
+
+    def test_login_returns_429_when_rate_limited(self) -> None:
+        """POST /auth/login returns 429 after exceeding rate limit."""
+        limiter = CountingRateLimiter()
+        settings = AppSettings(
+            DATABASE_URL="memory://",
+            SECRET_KEY=TEST_SECRET,
+            RATE_LIMIT_ENABLED=True,
+            RATE_LIMIT_LOGIN_MAX=2,
+            RATE_LIMIT_LOGIN_WINDOW=60,
+        )
+        client = _client_with_limiter(limiter, settings)
+
+        # Make requests up to the limit (wrong password = 401, but counts)
+        for _ in range(2):
+            client.post(
+                "/auth/login",
+                json={"email": "test@example.com", "password": "wrong"},
+            )
+
+        # This one should be rate limited
+        resp = client.post(
+            "/auth/login",
+            json={"email": "test@example.com", "password": "wrong"},
+        )
+        assert resp.status_code == 429
+        body = resp.json()
+        assert body["detail"] == "Too many requests"
+
+    def test_books_returns_429_when_rate_limited(self) -> None:
+        """GET /books returns 429 after exceeding global rate limit."""
+        limiter = CountingRateLimiter()
+        settings = AppSettings(
+            DATABASE_URL="memory://",
+            SECRET_KEY=TEST_SECRET,
+            RATE_LIMIT_ENABLED=True,
+            RATE_LIMIT_GLOBAL_MAX=2,
+            RATE_LIMIT_GLOBAL_WINDOW=60,
+        )
+        client = _client_with_limiter(limiter, settings)
+        headers = _auth_headers()
+
+        # Exhaust the limit
+        for _ in range(2):
+            client.get("/books", headers=headers)
+
+        # Should be rate limited
+        resp = client.get("/books", headers=headers)
+        assert resp.status_code == 429
+
+
+class TestRateLimitHeaders:
+    """T14: Test that rate limit headers are present on responses."""
+
+    def test_429_includes_all_ietf_headers(self) -> None:
+        """429 response includes Retry-After, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset."""
+        limiter = CountingRateLimiter()
+        settings = AppSettings(
+            DATABASE_URL="memory://",
+            SECRET_KEY=TEST_SECRET,
+            RATE_LIMIT_ENABLED=True,
+            RATE_LIMIT_GLOBAL_MAX=1,
+            RATE_LIMIT_GLOBAL_WINDOW=60,
+        )
+        client = _client_with_limiter(limiter, settings)
+        headers = _auth_headers()
+
+        # First request — allowed
+        client.get("/books", headers=headers)
+
+        # Second request — blocked
+        resp = client.get("/books", headers=headers)
+        assert resp.status_code == 429
+
+        # Verify all 4 IETF headers
+        assert "Retry-After" in resp.headers
+        assert "RateLimit-Limit" in resp.headers
+        assert "RateLimit-Remaining" in resp.headers
+        assert "RateLimit-Reset" in resp.headers
+
+        assert resp.headers["RateLimit-Limit"] == "1"
+        assert resp.headers["RateLimit-Remaining"] == "0"
+        assert int(resp.headers["Retry-After"]) > 0
+        assert int(resp.headers["RateLimit-Reset"]) > 0
+
+    def test_successful_response_includes_ratelimit_headers(self) -> None:
+        """Successful (non-429) responses include RateLimit-* headers."""
+        limiter = CountingRateLimiter()
+        settings = AppSettings(
+            DATABASE_URL="memory://",
+            SECRET_KEY=TEST_SECRET,
+            RATE_LIMIT_ENABLED=True,
+            RATE_LIMIT_GLOBAL_MAX=10,
+            RATE_LIMIT_GLOBAL_WINDOW=60,
+        )
+        client = _client_with_limiter(limiter, settings)
+        headers = _auth_headers()
+
+        resp = client.get("/books", headers=headers)
+        assert resp.status_code == 200
+
+        # RateLimit headers should be present on successful responses
+        assert "RateLimit-Limit" in resp.headers
+        assert "RateLimit-Remaining" in resp.headers
+        assert "RateLimit-Reset" in resp.headers
+        assert resp.headers["RateLimit-Limit"] == "10"
+
+
+class TestHealthExempt:
+    """T14: Test that /health is never rate limited."""
+
+    def test_health_not_rate_limited_even_under_load(self) -> None:
+        """GET /health always returns 200 regardless of rate limit state."""
+        limiter = CountingRateLimiter()
+        settings = AppSettings(
+            DATABASE_URL="memory://",
+            SECRET_KEY=TEST_SECRET,
+            RATE_LIMIT_ENABLED=True,
+            RATE_LIMIT_GLOBAL_MAX=1,
+            RATE_LIMIT_GLOBAL_WINDOW=60,
+        )
+        client = _client_with_limiter(limiter, settings)
+        headers = _auth_headers()
+
+        # Exhaust rate limit on another endpoint
+        client.get("/books", headers=headers)
+        resp = client.get("/books", headers=headers)
+        assert resp.status_code == 429
+
+        # Health should still work — NO rate limit dependency
+        for _ in range(10):
+            resp = client.get("/health")
+            assert resp.status_code == 200
+
+
+class TestRateLimitWindowReset:
+    """T14: Test that rate limiting resets after window expires."""
+
+    def test_rate_limit_resets_after_window(self) -> None:
+        """After the window expires, requests are allowed again."""
+        limiter = CountingRateLimiter()
+        settings = AppSettings(
+            DATABASE_URL="memory://",
+            SECRET_KEY=TEST_SECRET,
+            RATE_LIMIT_ENABLED=True,
+            RATE_LIMIT_GLOBAL_MAX=2,
+            RATE_LIMIT_GLOBAL_WINDOW=1,  # 1 second window for fast test
+        )
+        client = _client_with_limiter(limiter, settings)
+        headers = _auth_headers()
+
+        # Exhaust the limit
+        client.get("/books", headers=headers)
+        client.get("/books", headers=headers)
+        resp = client.get("/books", headers=headers)
+        assert resp.status_code == 429
+
+        # Wait for the window to expire
+        time.sleep(1.1)
+
+        # Should be allowed again
+        resp = client.get("/books", headers=headers)
+        assert resp.status_code == 200
+
+
+class TestFailOpen:
+    """T16: Test fail-open behavior when Redis is unavailable."""
+
+    def test_requests_succeed_when_redis_unavailable(self) -> None:
+        """Requests pass through when limiter raises ConnectionError."""
+        limiter = _broken_limiter()
+        settings = AppSettings(
+            DATABASE_URL="memory://",
+            SECRET_KEY=TEST_SECRET,
+            RATE_LIMIT_ENABLED=True,
+        )
+        client = _client_with_limiter(limiter, settings)
+        headers = _auth_headers()
+
+        # All requests should succeed despite broken limiter
+        for _ in range(10):
+            resp = client.get("/books", headers=headers)
+            assert resp.status_code == 200
+
+    def test_login_succeeds_when_redis_unavailable(self) -> None:
+        """Auth endpoints pass through when limiter is down."""
+        limiter = _broken_limiter()
+        settings = AppSettings(
+            DATABASE_URL="memory://",
+            SECRET_KEY=TEST_SECRET,
+            RATE_LIMIT_ENABLED=True,
+        )
+        client = _client_with_limiter(limiter, settings)
+
+        # Login should succeed (may return 401 for wrong creds, but NOT 429)
+        resp = client.post(
+            "/auth/login",
+            json={"email": "test@example.com", "password": "wrong"},
+        )
+        assert resp.status_code != 429
+
+
+class TestKeyIsolation:
+    """T18: Test that rate limits are per-IP, per-endpoint."""
+
+    def test_different_endpoints_independent_limits(self) -> None:
+        """Rate limits on /books and /collections are independent."""
+        limiter = CountingRateLimiter()
+        settings = AppSettings(
+            DATABASE_URL="memory://",
+            SECRET_KEY=TEST_SECRET,
+            RATE_LIMIT_ENABLED=True,
+            RATE_LIMIT_GLOBAL_MAX=1,
+            RATE_LIMIT_GLOBAL_WINDOW=60,
+        )
+        client = _client_with_limiter(limiter, settings)
+        headers = _auth_headers()
+
+        # Exhaust limit on /books
+        resp1 = client.get("/books", headers=headers)
+        assert resp1.status_code == 200
+        resp2 = client.get("/books", headers=headers)
+        assert resp2.status_code == 429
+
+        # /collections should still be available (different path = different key)
+        resp3 = client.get("/collections", headers=headers)
+        assert resp3.status_code == 200
+
+    def test_different_ips_independent_limits(self) -> None:
+        """Rate limits for different client IPs are independent."""
+        limiter = CountingRateLimiter()
+        settings = AppSettings(
+            DATABASE_URL="memory://",
+            SECRET_KEY=TEST_SECRET,
+            RATE_LIMIT_ENABLED=True,
+            RATE_LIMIT_GLOBAL_MAX=1,
+            RATE_LIMIT_GLOBAL_WINDOW=60,
+        )
+        client = _client_with_limiter(limiter, settings)
+
+        # Exhaust limit for IP 1
+        resp = client.get("/books", headers={
+            **_auth_headers(),
+            "X-Forwarded-For": "10.0.0.1",
+        })
+        assert resp.status_code == 200
+        resp = client.get("/books", headers={
+            **_auth_headers(),
+            "X-Forwarded-For": "10.0.0.1",
+        })
+        assert resp.status_code == 429
+
+        # Different IP should be allowed
+        resp = client.get("/books", headers={
+            **_auth_headers(),
+            "X-Forwarded-For": "10.0.0.2",
+        })
+        assert resp.status_code == 200

--- a/tests/unit/test_rate_limiting/test_t10_exception_handler.py
+++ b/tests/unit/test_rate_limiting/test_t10_exception_handler.py
@@ -57,7 +57,7 @@ class TestRateLimitExceptionHandler:
         }
         request = Request(scope)
 
-        exc = RateLimitExceededError(retry_after=60)
+        exc = RateLimitExceededError(retry_after=60, limit=10)
         import asyncio
 
         response = asyncio.run(handler(request, exc))
@@ -85,7 +85,7 @@ class TestRateLimitExceptionHandler:
         }
         request = Request(scope)
 
-        exc = RateLimitExceededError(retry_after=45)
+        exc = RateLimitExceededError(retry_after=45, limit=10)
         import asyncio
 
         response = asyncio.run(handler(request, exc))

--- a/tests/unit/test_rate_limiting/test_t10_exception_handler.py
+++ b/tests/unit/test_rate_limiting/test_t10_exception_handler.py
@@ -2,13 +2,11 @@
 
 from __future__ import annotations
 
-import pytest
 from fastapi.testclient import TestClient
 
 from config.settings import AppSettings
 from domain.rate_limiting.exceptions import RateLimitExceededError
 from main import create_app
-
 
 TEST_SECRET = "test-secret-key-at-least-32-chars-long"
 
@@ -32,16 +30,14 @@ class TestRateLimitExceptionHandler:
 
         # Verify the handler is registered by checking exception handlers
         # The handler should be in the app's exception handlers
-        from starlette.exceptions import HTTPException as StarletteHTTPException
 
         # Check that RateLimitExceededError is handled
         handler = app.exception_handlers.get(RateLimitExceededError)
         assert handler is not None, "RateLimitExceededError handler not registered"
 
     def test_handler_returns_correct_body(self) -> None:
-        """Handler returns {\"detail\": \"Too many requests\"}."""
+        r"""Handler returns {\"detail\": \"Too many requests\"}."""
         from starlette.requests import Request
-        from starlette.responses import JSONResponse
 
         client = self._make_app()
         app = client.app
@@ -90,3 +86,41 @@ class TestRateLimitExceptionHandler:
 
         response = asyncio.run(handler(request, exc))
         assert response.headers["Retry-After"] == "45"
+
+    def test_handler_sets_all_four_ietf_headers(self) -> None:
+        """T15: 429 response includes all 4 IETF RateLimit headers.
+
+        Verifies REQ-RL-003: Retry-After, RateLimit-Limit,
+        RateLimit-Remaining, and RateLimit-Reset are all present.
+        """
+        from starlette.requests import Request
+
+        client = self._make_app()
+        app = client.app
+        handler = app.exception_handlers[RateLimitExceededError]
+
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/test",
+            "query_string": b"",
+            "headers": [],
+        }
+        request = Request(scope)
+
+        exc = RateLimitExceededError(retry_after=30, limit=5)
+        import asyncio
+
+        response = asyncio.run(handler(request, exc))
+
+        # All 4 IETF headers must be present
+        assert "Retry-After" in response.headers
+        assert "RateLimit-Limit" in response.headers
+        assert "RateLimit-Remaining" in response.headers
+        assert "RateLimit-Reset" in response.headers
+
+        # Verify values
+        assert response.headers["Retry-After"] == "30"
+        assert response.headers["RateLimit-Limit"] == "5"
+        assert response.headers["RateLimit-Remaining"] == "0"
+        assert int(response.headers["RateLimit-Reset"]) > 0

--- a/tests/unit/test_rate_limiting/test_t10_exception_handler.py
+++ b/tests/unit/test_rate_limiting/test_t10_exception_handler.py
@@ -1,0 +1,92 @@
+"""T10: Unit tests for 429 RateLimitExceededError handler in main.py."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from config.settings import AppSettings
+from domain.rate_limiting.exceptions import RateLimitExceededError
+from main import create_app
+
+
+TEST_SECRET = "test-secret-key-at-least-32-chars-long"
+
+
+class TestRateLimitExceptionHandler:
+    """Test the 429 exception handler registered in create_app()."""
+
+    def _make_app(self) -> TestClient:
+        """Create a test client with rate limiting disabled (NoOp)."""
+        settings = AppSettings(
+            DATABASE_URL="memory://",
+            SECRET_KEY=TEST_SECRET,
+            RATE_LIMIT_ENABLED=False,
+        )
+        return TestClient(create_app(settings))
+
+    def test_handler_returns_429_status(self) -> None:
+        """RateLimitExceededError handler returns HTTP 429."""
+        client = self._make_app()
+        app = client.app
+
+        # Verify the handler is registered by checking exception handlers
+        # The handler should be in the app's exception handlers
+        from starlette.exceptions import HTTPException as StarletteHTTPException
+
+        # Check that RateLimitExceededError is handled
+        handler = app.exception_handlers.get(RateLimitExceededError)
+        assert handler is not None, "RateLimitExceededError handler not registered"
+
+    def test_handler_returns_correct_body(self) -> None:
+        """Handler returns {\"detail\": \"Too many requests\"}."""
+        from starlette.requests import Request
+        from starlette.responses import JSONResponse
+
+        client = self._make_app()
+        app = client.app
+        handler = app.exception_handlers[RateLimitExceededError]
+
+        # Create a mock request
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/test",
+            "query_string": b"",
+            "headers": [],
+        }
+        request = Request(scope)
+
+        exc = RateLimitExceededError(retry_after=60)
+        import asyncio
+
+        response = asyncio.run(handler(request, exc))
+        assert response.status_code == 429
+
+        import json
+
+        body = json.loads(response.body)
+        assert body == {"detail": "Too many requests"}
+
+    def test_handler_sets_retry_after_header(self) -> None:
+        """Handler sets Retry-After header from exception."""
+        from starlette.requests import Request
+
+        client = self._make_app()
+        app = client.app
+        handler = app.exception_handlers[RateLimitExceededError]
+
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/test",
+            "query_string": b"",
+            "headers": [],
+        }
+        request = Request(scope)
+
+        exc = RateLimitExceededError(retry_after=45)
+        import asyncio
+
+        response = asyncio.run(handler(request, exc))
+        assert response.headers["Retry-After"] == "45"

--- a/tests/unit/test_rate_limiting/test_t11_t12_auth_rate_limit.py
+++ b/tests/unit/test_rate_limiting/test_t11_t12_auth_rate_limit.py
@@ -1,0 +1,116 @@
+"""T11/T12: Tests for rate limiting on auth endpoints."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.dependencies import _reset_repos, get_rate_limiter
+from config.settings import AppSettings
+from domain.rate_limiting.exceptions import RateLimitExceededError
+from domain.rate_limiting.ports import RateLimiter
+from infrastructure.rate_limiting.noop_rate_limiter import NoOpRateLimiter
+from main import create_app
+
+
+TEST_SECRET = "test-secret-key-at-least-32-chars-long"
+
+
+class TestLoginRateLimit:
+    """Test rate limiting on POST /auth/login."""
+
+    def _make_client(self) -> TestClient:
+        """Create a test client with NoOpRateLimiter override."""
+        _reset_repos()
+        settings = AppSettings(
+            DATABASE_URL="memory://",
+            SECRET_KEY=TEST_SECRET,
+            RATE_LIMIT_ENABLED=True,
+        )
+        app = create_app(settings)
+        app.dependency_overrides[get_rate_limiter] = lambda: NoOpRateLimiter()
+        return TestClient(app)
+
+    def test_login_endpoint_accepts_rate_limit_dependency(self) -> None:
+        """Login endpoint must have require_rate_limit wired as dependency."""
+        client = self._make_client()
+        response = client.post("/auth/login", json={
+            "email": "test@example.com",
+            "password": "wrong",
+        })
+        # Should get 401 (invalid credentials), not 500 (missing dependency)
+        assert response.status_code == 401
+
+    def test_login_returns_429_when_rate_limited(self) -> None:
+        """Login returns 429 when rate limiter blocks the request."""
+        mock_limiter = AsyncMock(spec=RateLimiter)
+        mock_limiter.check.return_value = False
+
+        _reset_repos()
+        settings = AppSettings(
+            DATABASE_URL="memory://",
+            SECRET_KEY=TEST_SECRET,
+            RATE_LIMIT_ENABLED=True,
+        )
+        app = create_app(settings)
+        app.dependency_overrides[get_rate_limiter] = lambda: mock_limiter
+        client = TestClient(app)
+
+        response = client.post("/auth/login", json={
+            "email": "test@example.com",
+            "password": "wrong",
+        })
+        assert response.status_code == 429
+        assert response.json() == {"detail": "Too many requests"}
+        assert "Retry-After" in response.headers
+
+
+class TestRegisterRateLimit:
+    """Test rate limiting on POST /auth/register."""
+
+    def _make_client(self) -> TestClient:
+        """Create a test client with NoOpRateLimiter override."""
+        _reset_repos()
+        settings = AppSettings(
+            DATABASE_URL="memory://",
+            SECRET_KEY=TEST_SECRET,
+            RATE_LIMIT_ENABLED=True,
+        )
+        app = create_app(settings)
+        app.dependency_overrides[get_rate_limiter] = lambda: NoOpRateLimiter()
+        return TestClient(app)
+
+    def test_register_endpoint_accepts_rate_limit_dependency(self) -> None:
+        """Register endpoint must have require_rate_limit wired as dependency."""
+        client = self._make_client()
+        response = client.post("/auth/register", json={
+            "email": "test@example.com",
+            "password": "password123",
+        })
+        # Should not get 500 (missing dependency)
+        assert response.status_code in (201, 409, 422)
+
+    def test_register_returns_429_when_rate_limited(self) -> None:
+        """Register returns 429 when rate limiter blocks the request."""
+        mock_limiter = AsyncMock(spec=RateLimiter)
+        mock_limiter.check.return_value = False
+
+        _reset_repos()
+        settings = AppSettings(
+            DATABASE_URL="memory://",
+            SECRET_KEY=TEST_SECRET,
+            RATE_LIMIT_ENABLED=True,
+        )
+        app = create_app(settings)
+        app.dependency_overrides[get_rate_limiter] = lambda: mock_limiter
+        client = TestClient(app)
+
+        response = client.post("/auth/register", json={
+            "email": "test@example.com",
+            "password": "password123",
+        })
+        assert response.status_code == 429
+        assert response.json() == {"detail": "Too many requests"}
+        assert "Retry-After" in response.headers

--- a/tests/unit/test_rate_limiting/test_t11_t12_auth_rate_limit.py
+++ b/tests/unit/test_rate_limiting/test_t11_t12_auth_rate_limit.py
@@ -4,16 +4,13 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock
 
-import pytest
 from fastapi.testclient import TestClient
 
 from api.dependencies import _reset_repos, get_rate_limiter
 from config.settings import AppSettings
-from domain.rate_limiting.exceptions import RateLimitExceededError
 from domain.rate_limiting.ports import RateLimiter
 from infrastructure.rate_limiting.noop_rate_limiter import NoOpRateLimiter
 from main import create_app
-
 
 TEST_SECRET = "test-secret-key-at-least-32-chars-long"
 

--- a/tests/unit/test_rate_limiting/test_t13_global_rate_limit.py
+++ b/tests/unit/test_rate_limiting/test_t13_global_rate_limit.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock
 
-import pytest
 from fastapi.testclient import TestClient
 
 from api.dependencies import _reset_repos, get_rate_limiter
@@ -12,7 +11,6 @@ from config.settings import AppSettings
 from domain.rate_limiting.ports import RateLimiter
 from infrastructure.rate_limiting.noop_rate_limiter import NoOpRateLimiter
 from main import create_app
-
 
 TEST_SECRET = "test-secret-key-at-least-32-chars-long"
 

--- a/tests/unit/test_rate_limiting/test_t13_global_rate_limit.py
+++ b/tests/unit/test_rate_limiting/test_t13_global_rate_limit.py
@@ -1,0 +1,142 @@
+"""T13: Tests for global rate limiting on books, collections, favorites endpoints."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.dependencies import _reset_repos, get_rate_limiter
+from config.settings import AppSettings
+from domain.rate_limiting.ports import RateLimiter
+from infrastructure.rate_limiting.noop_rate_limiter import NoOpRateLimiter
+from main import create_app
+
+
+TEST_SECRET = "test-secret-key-at-least-32-chars-long"
+
+
+def _make_client(
+    mock_limiter: RateLimiter | None = None,
+) -> TestClient:
+    """Create a test client with rate limiting override.
+
+    Args:
+        mock_limiter: Optional mock limiter. If None, uses NoOpRateLimiter.
+
+    Returns:
+        Configured TestClient instance.
+    """
+    _reset_repos()
+    settings = AppSettings(
+        DATABASE_URL="memory://",
+        SECRET_KEY=TEST_SECRET,
+        RATE_LIMIT_ENABLED=True,
+    )
+    app = create_app(settings)
+    limiter = mock_limiter if mock_limiter is not None else NoOpRateLimiter()
+    app.dependency_overrides[get_rate_limiter] = lambda: limiter
+    return TestClient(app)
+
+
+def _auth_headers(user_id: str = "test-user-id", role: str = "user") -> dict[str, str]:
+    """Create Authorization headers."""
+    from infrastructure.auth.jwt_token_service import JwtTokenService
+
+    token_service = JwtTokenService(TEST_SECRET)
+    token = token_service.generate(user_id, role)
+    return {"Authorization": f"Bearer {token}"}
+
+
+class TestBooksGlobalRateLimit:
+    """Test global rate limiting on books endpoints."""
+
+    def test_list_books_has_rate_limit_dependency(self) -> None:
+        """GET /books must have global rate limit dependency wired."""
+        client = _make_client()
+        resp = client.get("/books", headers=_auth_headers())
+        # Should work with NoOpRateLimiter (not 500)
+        assert resp.status_code == 200
+
+    def test_list_books_returns_429_when_rate_limited(self) -> None:
+        """GET /books returns 429 when rate limiter blocks."""
+        mock = AsyncMock(spec=RateLimiter)
+        mock.check.return_value = False
+        client = _make_client(mock)
+        resp = client.get("/books", headers=_auth_headers())
+        assert resp.status_code == 429
+        assert resp.json() == {"detail": "Too many requests"}
+
+    def test_create_book_returns_429_when_rate_limited(self) -> None:
+        """POST /books returns 429 when rate limiter blocks."""
+        mock = AsyncMock(spec=RateLimiter)
+        mock.check.return_value = False
+        client = _make_client(mock)
+        resp = client.post(
+            "/books",
+            json={"name": "Test", "author": "A"},
+            headers=_auth_headers(role="admin"),
+        )
+        assert resp.status_code == 429
+
+
+class TestCollectionsGlobalRateLimit:
+    """Test global rate limiting on collections endpoints."""
+
+    def test_list_collections_has_rate_limit_dependency(self) -> None:
+        """GET /collections must have global rate limit dependency wired."""
+        client = _make_client()
+        resp = client.get("/collections", headers=_auth_headers())
+        assert resp.status_code == 200
+
+    def test_list_collections_returns_429_when_rate_limited(self) -> None:
+        """GET /collections returns 429 when rate limiter blocks."""
+        mock = AsyncMock(spec=RateLimiter)
+        mock.check.return_value = False
+        client = _make_client(mock)
+        resp = client.get("/collections", headers=_auth_headers())
+        assert resp.status_code == 429
+
+    def test_create_collection_returns_429_when_rate_limited(self) -> None:
+        """POST /collections returns 429 when rate limiter blocks."""
+        mock = AsyncMock(spec=RateLimiter)
+        mock.check.return_value = False
+        client = _make_client(mock)
+        resp = client.post(
+            "/collections",
+            json={"name": "Test"},
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 429
+
+
+class TestFavoritesGlobalRateLimit:
+    """Test global rate limiting on favorites endpoints."""
+
+    def test_list_favorites_has_rate_limit_dependency(self) -> None:
+        """GET /favorites must have global rate limit dependency wired."""
+        client = _make_client()
+        resp = client.get("/favorites", headers=_auth_headers())
+        assert resp.status_code == 200
+
+    def test_list_favorites_returns_429_when_rate_limited(self) -> None:
+        """GET /favorites returns 429 when rate limiter blocks."""
+        mock = AsyncMock(spec=RateLimiter)
+        mock.check.return_value = False
+        client = _make_client(mock)
+        resp = client.get("/favorites", headers=_auth_headers())
+        assert resp.status_code == 429
+
+
+class TestHealthExemptFromRateLimit:
+    """Test that /health is exempt from rate limiting."""
+
+    def test_health_not_rate_limited(self) -> None:
+        """GET /health works even when rate limiter would block."""
+        mock = AsyncMock(spec=RateLimiter)
+        mock.check.return_value = False
+        client = _make_client(mock)
+        resp = client.get("/health")
+        # Health should succeed even with blocking limiter
+        assert resp.status_code == 200

--- a/tests/unit/test_rate_limiting/test_t1_dependency.py
+++ b/tests/unit/test_rate_limiting/test_t1_dependency.py
@@ -1,0 +1,15 @@
+"""Tests for T1: redis dependency is importable."""
+
+
+def test_redis_is_importable():
+    """Verify redis package is installed and importable."""
+    import redis
+
+    assert redis.__version__
+
+
+def test_redis_asyncio_is_importable():
+    """Verify redis.asyncio (async client) is available."""
+    import redis.asyncio
+
+    assert hasattr(redis.asyncio, "Redis")

--- a/tests/unit/test_rate_limiting/test_t2_settings.py
+++ b/tests/unit/test_rate_limiting/test_t2_settings.py
@@ -1,0 +1,60 @@
+"""Tests for T2: rate-limit settings in AppSettings."""
+
+from __future__ import annotations
+
+from config.settings import AppSettings
+
+
+class TestRateLimitSettings:
+    """Verify rate-limit configuration fields exist with correct defaults."""
+
+    def test_settings_has_rate_limit_enabled(self) -> None:
+        """RATE_LIMIT_ENABLED defaults to True."""
+        settings = AppSettings()
+        assert settings.RATE_LIMIT_ENABLED is True
+
+    def test_settings_has_rate_limit_fail_open(self) -> None:
+        """RATE_LIMIT_FAIL_OPEN defaults to True."""
+        settings = AppSettings()
+        assert settings.RATE_LIMIT_FAIL_OPEN is True
+
+    def test_settings_has_rate_limit_login_max(self) -> None:
+        """RATE_LIMIT_LOGIN_MAX defaults to 5."""
+        settings = AppSettings()
+        assert settings.RATE_LIMIT_LOGIN_MAX == 5
+
+    def test_settings_has_rate_limit_login_window(self) -> None:
+        """RATE_LIMIT_LOGIN_WINDOW defaults to 60 seconds."""
+        settings = AppSettings()
+        assert settings.RATE_LIMIT_LOGIN_WINDOW == 60
+
+    def test_settings_has_rate_limit_register_max(self) -> None:
+        """RATE_LIMIT_REGISTER_MAX defaults to 3."""
+        settings = AppSettings()
+        assert settings.RATE_LIMIT_REGISTER_MAX == 3
+
+    def test_settings_has_rate_limit_register_window(self) -> None:
+        """RATE_LIMIT_REGISTER_WINDOW defaults to 60 seconds."""
+        settings = AppSettings()
+        assert settings.RATE_LIMIT_REGISTER_WINDOW == 60
+
+    def test_settings_has_rate_limit_global_max(self) -> None:
+        """RATE_LIMIT_GLOBAL_MAX defaults to 100."""
+        settings = AppSettings()
+        assert settings.RATE_LIMIT_GLOBAL_MAX == 100
+
+    def test_settings_has_rate_limit_global_window(self) -> None:
+        """RATE_LIMIT_GLOBAL_WINDOW defaults to 60 seconds."""
+        settings = AppSettings()
+        assert settings.RATE_LIMIT_GLOBAL_WINDOW == 60
+
+    def test_settings_can_override_via_env(self, monkeypatch: object) -> None:
+        """Rate limit fields can be overridden via environment variables."""
+        import os
+
+        os.environ["RATE_LIMIT_LOGIN_MAX"] = "10"
+        try:
+            settings = AppSettings()
+            assert settings.RATE_LIMIT_LOGIN_MAX == 10
+        finally:
+            del os.environ["RATE_LIMIT_LOGIN_MAX"]

--- a/tests/unit/test_rate_limiting/test_t3_ports.py
+++ b/tests/unit/test_rate_limiting/test_t3_ports.py
@@ -1,0 +1,75 @@
+"""Tests for T3: RateLimiter ABC port."""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+
+class TestRateLimiterABC:
+    """Verify RateLimiter is a proper abstract base class."""
+
+    def test_rate_limiter_is_importable(self) -> None:
+        """RateLimiter can be imported from domain.rate_limiting."""
+        from domain.rate_limiting import RateLimiter
+
+        assert RateLimiter is not None
+
+    def test_rate_limiter_is_abstract(self) -> None:
+        """RateLimiter cannot be instantiated directly."""
+        from domain.rate_limiting import RateLimiter
+
+        with pytest.raises(TypeError, match="abstract"):
+            RateLimiter()  # type: ignore[abstract]
+
+    def test_rate_limiter_has_check_method(self) -> None:
+        """RateLimiter defines async check() method."""
+        from domain.rate_limiting import RateLimiter
+
+        assert hasattr(RateLimiter, "check")
+        assert inspect.iscoroutinefunction(RateLimiter.check)
+
+    def test_rate_limiter_has_reset_method(self) -> None:
+        """RateLimiter defines async reset() method."""
+        from domain.rate_limiting import RateLimiter
+
+        assert hasattr(RateLimiter, "reset")
+        assert inspect.iscoroutinefunction(RateLimiter.reset)
+
+    def test_check_method_signature(self) -> None:
+        """check() accepts key, max_requests, window_seconds and returns bool."""
+        import typing
+
+        from domain.rate_limiting import RateLimiter
+
+        hints = typing.get_type_hints(RateLimiter.check)
+        assert hints["key"] is str
+        assert hints["max_requests"] is int
+        assert hints["window_seconds"] is int
+        assert hints["return"] is bool
+
+    def test_reset_method_signature(self) -> None:
+        """reset() accepts key and returns None."""
+        import typing
+
+        from domain.rate_limiting import RateLimiter
+
+        hints = typing.get_type_hints(RateLimiter.reset)
+        assert hints["key"] is str
+        assert hints["return"] is type(None)
+
+    def test_concrete_implementation_works(self) -> None:
+        """A concrete subclass of RateLimiter can be instantiated."""
+
+        from domain.rate_limiting import RateLimiter
+
+        class StubRateLimiter(RateLimiter):
+            async def check(self, key: str, max_requests: int, window_seconds: int) -> bool:
+                return True
+
+            async def reset(self, key: str) -> None:
+                pass
+
+        limiter = StubRateLimiter()
+        assert limiter is not None

--- a/tests/unit/test_rate_limiting/test_t3_ports.py
+++ b/tests/unit/test_rate_limiting/test_t3_ports.py
@@ -61,7 +61,6 @@ class TestRateLimiterABC:
 
     def test_concrete_implementation_works(self) -> None:
         """A concrete subclass of RateLimiter can be instantiated."""
-
         from domain.rate_limiting import RateLimiter
 
         class StubRateLimiter(RateLimiter):

--- a/tests/unit/test_rate_limiting/test_t4_exceptions.py
+++ b/tests/unit/test_rate_limiting/test_t4_exceptions.py
@@ -1,0 +1,61 @@
+"""Tests for T4: RateLimitExceeded exception."""
+
+from __future__ import annotations
+
+
+class TestRateLimitExceeded:
+    """Verify RateLimitExceeded is a proper domain exception."""
+
+    def test_exception_is_importable(self) -> None:
+        """RateLimitExceeded can be imported from domain.rate_limiting."""
+        from domain.rate_limiting.exceptions import RateLimitExceeded
+
+        assert RateLimitExceeded is not None
+
+    def test_exception_extends_domain_error(self) -> None:
+        """RateLimitExceeded is a subclass of DomainError."""
+        from domain.exceptions import DomainError
+        from domain.rate_limiting.exceptions import RateLimitExceeded
+
+        assert issubclass(RateLimitExceeded, DomainError)
+
+    def test_exception_is_subclass_of_exception(self) -> None:
+        """RateLimitExceeded is ultimately an Exception."""
+        from domain.rate_limiting.exceptions import RateLimitExceeded
+
+        assert issubclass(RateLimitExceeded, Exception)
+
+    def test_exception_has_retry_after_field(self) -> None:
+        """RateLimitExceeded carries a retry_after integer field."""
+        from domain.rate_limiting.exceptions import RateLimitExceeded
+
+        exc = RateLimitExceeded(retry_after=30)
+        assert exc.retry_after == 30
+
+    def test_exception_str_representation(self) -> None:
+        """RateLimitExceeded has a readable string representation."""
+        from domain.rate_limiting.exceptions import RateLimitExceeded
+
+        exc = RateLimitExceeded(retry_after=45)
+        result = str(exc)
+        assert "45" in result
+        assert len(result) > 0
+
+    def test_exception_can_be_raised_and_caught(self) -> None:
+        """RateLimitExceeded can be raised and caught as DomainError."""
+        import pytest
+
+        from domain.exceptions import DomainError
+        from domain.rate_limiting.exceptions import RateLimitExceeded
+
+        with pytest.raises(DomainError):
+            raise RateLimitExceeded(retry_after=10)
+
+    def test_exception_preserves_retry_after_after_raise(self) -> None:
+        """retry_after field survives exception propagation."""
+        from domain.rate_limiting.exceptions import RateLimitExceeded
+
+        try:
+            raise RateLimitExceeded(retry_after=60)
+        except RateLimitExceeded as exc:
+            assert exc.retry_after == 60

--- a/tests/unit/test_rate_limiting/test_t4_exceptions.py
+++ b/tests/unit/test_rate_limiting/test_t4_exceptions.py
@@ -29,14 +29,14 @@ class TestRateLimitExceededError:
         """RateLimitExceededError carries a retry_after integer field."""
         from domain.rate_limiting.exceptions import RateLimitExceededError
 
-        exc = RateLimitExceededError(retry_after=30)
+        exc = RateLimitExceededError(retry_after=30, limit=5)
         assert exc.retry_after == 30
 
     def test_exception_str_representation(self) -> None:
         """RateLimitExceededError has a readable string representation."""
         from domain.rate_limiting.exceptions import RateLimitExceededError
 
-        exc = RateLimitExceededError(retry_after=45)
+        exc = RateLimitExceededError(retry_after=45, limit=10)
         result = str(exc)
         assert "45" in result
         assert len(result) > 0
@@ -49,13 +49,13 @@ class TestRateLimitExceededError:
         from domain.rate_limiting.exceptions import RateLimitExceededError
 
         with pytest.raises(DomainError):
-            raise RateLimitExceededError(retry_after=10)
+            raise RateLimitExceededError(retry_after=10, limit=5)
 
     def test_exception_preserves_retry_after_after_raise(self) -> None:
         """retry_after field survives exception propagation."""
         from domain.rate_limiting.exceptions import RateLimitExceededError
 
         try:
-            raise RateLimitExceededError(retry_after=60)
+            raise RateLimitExceededError(retry_after=60, limit=10)
         except RateLimitExceededError as exc:
             assert exc.retry_after == 60

--- a/tests/unit/test_rate_limiting/test_t4_exceptions.py
+++ b/tests/unit/test_rate_limiting/test_t4_exceptions.py
@@ -1,61 +1,61 @@
-"""Tests for T4: RateLimitExceeded exception."""
+"""Tests for T4: RateLimitExceededError exception."""
 
 from __future__ import annotations
 
 
-class TestRateLimitExceeded:
-    """Verify RateLimitExceeded is a proper domain exception."""
+class TestRateLimitExceededError:
+    """Verify RateLimitExceededError is a proper domain exception."""
 
     def test_exception_is_importable(self) -> None:
-        """RateLimitExceeded can be imported from domain.rate_limiting."""
-        from domain.rate_limiting.exceptions import RateLimitExceeded
+        """RateLimitExceededError can be imported from domain.rate_limiting."""
+        from domain.rate_limiting.exceptions import RateLimitExceededError
 
-        assert RateLimitExceeded is not None
+        assert RateLimitExceededError is not None
 
     def test_exception_extends_domain_error(self) -> None:
-        """RateLimitExceeded is a subclass of DomainError."""
+        """RateLimitExceededError is a subclass of DomainError."""
         from domain.exceptions import DomainError
-        from domain.rate_limiting.exceptions import RateLimitExceeded
+        from domain.rate_limiting.exceptions import RateLimitExceededError
 
-        assert issubclass(RateLimitExceeded, DomainError)
+        assert issubclass(RateLimitExceededError, DomainError)
 
     def test_exception_is_subclass_of_exception(self) -> None:
-        """RateLimitExceeded is ultimately an Exception."""
-        from domain.rate_limiting.exceptions import RateLimitExceeded
+        """RateLimitExceededError is ultimately an Exception."""
+        from domain.rate_limiting.exceptions import RateLimitExceededError
 
-        assert issubclass(RateLimitExceeded, Exception)
+        assert issubclass(RateLimitExceededError, Exception)
 
     def test_exception_has_retry_after_field(self) -> None:
-        """RateLimitExceeded carries a retry_after integer field."""
-        from domain.rate_limiting.exceptions import RateLimitExceeded
+        """RateLimitExceededError carries a retry_after integer field."""
+        from domain.rate_limiting.exceptions import RateLimitExceededError
 
-        exc = RateLimitExceeded(retry_after=30)
+        exc = RateLimitExceededError(retry_after=30)
         assert exc.retry_after == 30
 
     def test_exception_str_representation(self) -> None:
-        """RateLimitExceeded has a readable string representation."""
-        from domain.rate_limiting.exceptions import RateLimitExceeded
+        """RateLimitExceededError has a readable string representation."""
+        from domain.rate_limiting.exceptions import RateLimitExceededError
 
-        exc = RateLimitExceeded(retry_after=45)
+        exc = RateLimitExceededError(retry_after=45)
         result = str(exc)
         assert "45" in result
         assert len(result) > 0
 
     def test_exception_can_be_raised_and_caught(self) -> None:
-        """RateLimitExceeded can be raised and caught as DomainError."""
+        """RateLimitExceededError can be raised and caught as DomainError."""
         import pytest
 
         from domain.exceptions import DomainError
-        from domain.rate_limiting.exceptions import RateLimitExceeded
+        from domain.rate_limiting.exceptions import RateLimitExceededError
 
         with pytest.raises(DomainError):
-            raise RateLimitExceeded(retry_after=10)
+            raise RateLimitExceededError(retry_after=10)
 
     def test_exception_preserves_retry_after_after_raise(self) -> None:
         """retry_after field survives exception propagation."""
-        from domain.rate_limiting.exceptions import RateLimitExceeded
+        from domain.rate_limiting.exceptions import RateLimitExceededError
 
         try:
-            raise RateLimitExceeded(retry_after=60)
-        except RateLimitExceeded as exc:
+            raise RateLimitExceededError(retry_after=60)
+        except RateLimitExceededError as exc:
             assert exc.retry_after == 60

--- a/tests/unit/test_rate_limiting/test_t5_noop.py
+++ b/tests/unit/test_rate_limiting/test_t5_noop.py
@@ -1,0 +1,47 @@
+"""T5: Unit tests for NoOpRateLimiter — always allows requests."""
+
+from __future__ import annotations
+
+import pytest
+
+from domain.rate_limiting.ports import RateLimiter
+from infrastructure.rate_limiting.noop_rate_limiter import NoOpRateLimiter
+
+
+class TestNoOpRateLimiter:
+    """Tests for NoOpRateLimiter behavior and contract compliance."""
+
+    @pytest.fixture
+    def limiter(self) -> NoOpRateLimiter:
+        """Provide a NoOpRateLimiter instance."""
+        return NoOpRateLimiter()
+
+    def test_is_instance_of_rate_limiter(self, limiter: NoOpRateLimiter) -> None:
+        """NoOpRateLimiter must implement the RateLimiter ABC."""
+        assert isinstance(limiter, RateLimiter)
+
+    @pytest.mark.asyncio
+    async def test_check_always_returns_true(self, limiter: NoOpRateLimiter) -> None:
+        """check() must always return True regardless of parameters."""
+        result = await limiter.check(key="any-key", max_requests=1, window_seconds=60)
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_check_returns_true_with_zero_limit(self, limiter: NoOpRateLimiter) -> None:
+        """check() returns True even when max_requests is 0 (would block real limiter)."""
+        result = await limiter.check(key="test", max_requests=0, window_seconds=60)
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_check_returns_true_with_various_keys(self, limiter: NoOpRateLimiter) -> None:
+        """check() returns True for any key string."""
+        keys = ["ip:path", "192.168.1.1:/api/books", "", "rate_limit:10.0.0.1:/auth/login"]
+        for key in keys:
+            result = await limiter.check(key=key, max_requests=10, window_seconds=60)
+            assert result is True
+
+    @pytest.mark.asyncio
+    async def test_reset_does_nothing(self, limiter: NoOpRateLimiter) -> None:
+        """reset() must complete without error (no-op)."""
+        await limiter.reset(key="any-key")
+        # No assertion needed — just verify it doesn't raise

--- a/tests/unit/test_rate_limiting/test_t6_redis_client.py
+++ b/tests/unit/test_rate_limiting/test_t6_redis_client.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
-
 from config.settings import AppSettings
 from infrastructure.rate_limiting.redis_client import create_redis_client
 

--- a/tests/unit/test_rate_limiting/test_t6_redis_client.py
+++ b/tests/unit/test_rate_limiting/test_t6_redis_client.py
@@ -1,0 +1,43 @@
+"""T6: Unit tests for Redis client factory."""
+
+from __future__ import annotations
+
+import pytest
+
+from config.settings import AppSettings
+from infrastructure.rate_limiting.redis_client import create_redis_client
+
+
+class TestCreateRedisClient:
+    """Tests for create_redis_client factory function."""
+
+    def test_returns_redis_client_from_settings_url(self) -> None:
+        """Factory must create a Redis client from the REDIS_URL setting."""
+        settings = AppSettings(
+            DATABASE_URL="memory://",
+            SECRET_KEY="test-secret-key-at-least-32-chars-long",
+            REDIS_URL="redis://localhost:6379/0",
+        )
+        client = create_redis_client(settings)
+        assert client is not None
+
+    def test_returns_client_with_custom_url(self) -> None:
+        """Factory must accept custom REDIS_URL values."""
+        settings = AppSettings(
+            DATABASE_URL="memory://",
+            SECRET_KEY="test-secret-key-at-least-32-chars-long",
+            REDIS_URL="redis://custom-host:6380/1",
+        )
+        client = create_redis_client(settings)
+        assert client is not None
+
+    def test_returns_async_redis_instance(self) -> None:
+        """Factory must return a redis.asyncio.Redis instance."""
+        import redis.asyncio
+
+        settings = AppSettings(
+            DATABASE_URL="memory://",
+            SECRET_KEY="test-secret-key-at-least-32-chars-long",
+        )
+        client = create_redis_client(settings)
+        assert isinstance(client, redis.asyncio.Redis)

--- a/tests/unit/test_rate_limiting/test_t7_redis_rate_limiter.py
+++ b/tests/unit/test_rate_limiting/test_t7_redis_rate_limiter.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import time
-
 import fakeredis
 import fakeredis.aioredis
 import pytest
@@ -138,4 +136,61 @@ class TestFailOpen:
 
         limiter = RedisRateLimiter(broken_redis)
         result = await limiter.check(key="test:fail", max_requests=1, window_seconds=60)
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_fail_open_on_timeout_error(self) -> None:
+        """T17: When Redis raises TimeoutError, check() must return True."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        broken_redis = MagicMock()
+        broken_redis.pipeline = MagicMock()
+        mock_pipe = MagicMock()
+        mock_pipe.zremrangebyscore = MagicMock(return_value=mock_pipe)
+        mock_pipe.zcard = MagicMock(return_value=mock_pipe)
+        mock_pipe.zadd = MagicMock(return_value=mock_pipe)
+        mock_pipe.expire = MagicMock(return_value=mock_pipe)
+        mock_pipe.execute = AsyncMock(side_effect=TimeoutError("Redis timeout"))
+        broken_redis.pipeline.return_value = mock_pipe
+
+        limiter = RedisRateLimiter(broken_redis)
+        result = await limiter.check(key="test:timeout", max_requests=1, window_seconds=60)
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_fail_open_on_redis_error(self) -> None:
+        """T17: When Redis raises RedisError, check() must return True."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        broken_redis = MagicMock()
+        broken_redis.pipeline = MagicMock()
+        mock_pipe = MagicMock()
+        mock_pipe.zremrangebyscore = MagicMock(return_value=mock_pipe)
+        mock_pipe.zcard = MagicMock(return_value=mock_pipe)
+        mock_pipe.zadd = MagicMock(return_value=mock_pipe)
+        mock_pipe.expire = MagicMock(return_value=mock_pipe)
+        mock_pipe.execute = AsyncMock(side_effect=Exception("WRONGTYPE Operation against a key"))
+        broken_redis.pipeline.return_value = mock_pipe
+
+        limiter = RedisRateLimiter(broken_redis)
+        result = await limiter.check(key="test:redis_error", max_requests=1, window_seconds=60)
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_fail_open_on_response_error(self) -> None:
+        """T17: When Redis raises ResponseError, check() must return True."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        broken_redis = MagicMock()
+        broken_redis.pipeline = MagicMock()
+        mock_pipe = MagicMock()
+        mock_pipe.zremrangebyscore = MagicMock(return_value=mock_pipe)
+        mock_pipe.zcard = MagicMock(return_value=mock_pipe)
+        mock_pipe.zadd = MagicMock(return_value=mock_pipe)
+        mock_pipe.expire = MagicMock(return_value=mock_pipe)
+        mock_pipe.execute = AsyncMock(side_effect=Exception("BUSY Redis is busy"))
+        broken_redis.pipeline.return_value = mock_pipe
+
+        limiter = RedisRateLimiter(broken_redis)
+        result = await limiter.check(key="test:response_error", max_requests=1, window_seconds=60)
         assert result is True

--- a/tests/unit/test_rate_limiting/test_t7_redis_rate_limiter.py
+++ b/tests/unit/test_rate_limiting/test_t7_redis_rate_limiter.py
@@ -1,0 +1,141 @@
+"""T7: Unit tests for RedisRateLimiter (sliding window via sorted sets)."""
+
+from __future__ import annotations
+
+import time
+
+import fakeredis
+import fakeredis.aioredis
+import pytest
+
+from domain.rate_limiting.ports import RateLimiter
+from infrastructure.rate_limiting.redis_rate_limiter import RedisRateLimiter
+
+
+@pytest.fixture
+def fake_redis() -> fakeredis.aioredis.FakeRedis:
+    """Provide a fake async Redis instance."""
+    return fakeredis.aioredis.FakeRedis()
+
+
+@pytest.fixture
+def limiter(fake_redis: fakeredis.FakeRedis) -> RedisRateLimiter:
+    """Provide a RedisRateLimiter with fake Redis."""
+    return RedisRateLimiter(fake_redis)
+
+
+class TestRedisRateLimiterContract:
+    """Verify RedisRateLimiter implements RateLimiter ABC."""
+
+    def test_is_instance_of_rate_limiter(self, limiter: RedisRateLimiter) -> None:
+        """Must implement the RateLimiter port."""
+        assert isinstance(limiter, RateLimiter)
+
+
+class TestCheckAllows:
+    """Test check() allows requests under the limit."""
+
+    @pytest.mark.asyncio
+    async def test_first_request_allowed(self, limiter: RedisRateLimiter) -> None:
+        """First request within window must be allowed."""
+        result = await limiter.check(key="test:key", max_requests=5, window_seconds=60)
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_requests_under_limit_allowed(self, limiter: RedisRateLimiter) -> None:
+        """Requests under the limit must all be allowed."""
+        for _ in range(5):
+            result = await limiter.check(key="test:key", max_requests=10, window_seconds=60)
+            assert result is True
+
+    @pytest.mark.asyncio
+    async def test_different_keys_independent(self, limiter: RedisRateLimiter) -> None:
+        """Rate limits on different keys must be independent."""
+        for _ in range(5):
+            await limiter.check(key="key-a", max_requests=5, window_seconds=60)
+
+        result = await limiter.check(key="key-b", max_requests=5, window_seconds=60)
+        assert result is True
+
+
+class TestCheckBlocks:
+    """Test check() blocks requests at or over the limit."""
+
+    @pytest.mark.asyncio
+    async def test_request_at_limit_blocked(self, limiter: RedisRateLimiter) -> None:
+        """Request that exceeds the limit must be blocked."""
+        for _ in range(3):
+            await limiter.check(key="test:block", max_requests=3, window_seconds=60)
+
+        result = await limiter.check(key="test:block", max_requests=3, window_seconds=60)
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_request_over_limit_blocked(self, limiter: RedisRateLimiter) -> None:
+        """Requests well over the limit must all be blocked."""
+        for _ in range(10):
+            await limiter.check(key="test:over", max_requests=2, window_seconds=60)
+
+        result = await limiter.check(key="test:over", max_requests=2, window_seconds=60)
+        assert result is False
+
+
+class TestSlidingWindow:
+    """Test that the sliding window expires old entries."""
+
+    @pytest.mark.asyncio
+    async def test_expired_entries_removed(self, limiter: RedisRateLimiter) -> None:
+        """After window expires, new requests must be allowed."""
+        for _ in range(3):
+            await limiter.check(key="test:expire", max_requests=3, window_seconds=1)
+
+        # Manually expire entries by waiting
+        import asyncio
+        await asyncio.sleep(1.1)
+
+        result = await limiter.check(key="test:expire", max_requests=3, window_seconds=1)
+        assert result is True
+
+
+class TestReset:
+    """Test reset() clears the rate limit counter."""
+
+    @pytest.mark.asyncio
+    async def test_reset_clears_counter(self, limiter: RedisRateLimiter) -> None:
+        """After reset, requests must be allowed again."""
+        for _ in range(3):
+            await limiter.check(key="test:reset", max_requests=3, window_seconds=60)
+
+        # Now at limit
+        result = await limiter.check(key="test:reset", max_requests=3, window_seconds=60)
+        assert result is False
+
+        # Reset
+        await limiter.reset(key="test:reset")
+
+        # Should be allowed again
+        result = await limiter.check(key="test:reset", max_requests=3, window_seconds=60)
+        assert result is True
+
+
+class TestFailOpen:
+    """Test fail-open behavior when Redis is unreachable."""
+
+    @pytest.mark.asyncio
+    async def test_fail_open_on_connection_error(self) -> None:
+        """When Redis raises ConnectionError, check() must return True."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        broken_redis = MagicMock()
+        broken_redis.pipeline = MagicMock()
+        mock_pipe = MagicMock()
+        mock_pipe.zremrangebyscore = MagicMock(return_value=mock_pipe)
+        mock_pipe.zcard = MagicMock(return_value=mock_pipe)
+        mock_pipe.zadd = MagicMock(return_value=mock_pipe)
+        mock_pipe.expire = MagicMock(return_value=mock_pipe)
+        mock_pipe.execute = AsyncMock(side_effect=ConnectionError("Connection refused"))
+        broken_redis.pipeline.return_value = mock_pipe
+
+        limiter = RedisRateLimiter(broken_redis)
+        result = await limiter.check(key="test:fail", max_requests=1, window_seconds=60)
+        assert result is True

--- a/tests/unit/test_rate_limiting/test_t8_rate_limit_middleware.py
+++ b/tests/unit/test_rate_limiting/test_t8_rate_limit_middleware.py
@@ -1,0 +1,174 @@
+"""T8: Unit tests for require_rate_limit() dependency factory."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from domain.rate_limiting.exceptions import RateLimitExceededError
+from domain.rate_limiting.ports import RateLimiter
+
+
+class TestExtractClientIp:
+    """Test IP extraction from request."""
+
+    def _make_request(
+        self,
+        client_host: str | None = "127.0.0.1",
+        x_forwarded_for: str | None = None,
+    ) -> MagicMock:
+        """Create a mock FastAPI Request."""
+        request = MagicMock()
+        request.client = MagicMock()
+        request.client.host = client_host
+        request.url = MagicMock()
+        request.url.path = "/test"
+        headers = {}
+        if x_forwarded_for is not None:
+            headers["x-forwarded-for"] = x_forwarded_for
+        request.headers = headers
+        return request
+
+    def test_uses_client_host_when_no_proxy_header(self) -> None:
+        """IP comes from request.client.host when no X-Forwarded-For."""
+        from api.middleware.rate_limit import _extract_client_ip
+
+        request = self._make_request(client_host="10.0.0.1")
+        assert _extract_client_ip(request) == "10.0.0.1"
+
+    def test_uses_first_forwarded_ip(self) -> None:
+        """IP comes from first entry in X-Forwarded-For."""
+        from api.middleware.rate_limit import _extract_client_ip
+
+        request = self._make_request(
+            client_host="10.0.0.1",
+            x_forwarded_for="203.0.113.50, 10.0.0.1",
+        )
+        assert _extract_client_ip(request) == "203.0.113.50"
+
+    def test_single_forwarded_ip(self) -> None:
+        """Single IP in X-Forwarded-For is used directly."""
+        from api.middleware.rate_limit import _extract_client_ip
+
+        request = self._make_request(
+            client_host="10.0.0.1",
+            x_forwarded_for="198.51.100.1",
+        )
+        assert _extract_client_ip(request) == "198.51.100.1"
+
+    def test_falls_back_when_client_is_none(self) -> None:
+        """Falls back to 'unknown' when request.client is None."""
+        from api.middleware.rate_limit import _extract_client_ip
+
+        request = MagicMock()
+        request.client = None
+        request.headers = {}
+        assert _extract_client_ip(request) == "unknown"
+
+
+class TestRequireRateLimitFactory:
+    """Test the require_rate_limit() factory function."""
+
+    @pytest.mark.asyncio
+    async def test_allows_request_under_limit(self) -> None:
+        """Dependency allows request when limiter returns True."""
+        from api.middleware.rate_limit import require_rate_limit
+
+        mock_limiter = AsyncMock(spec=RateLimiter)
+        mock_limiter.check.return_value = True
+
+        request = MagicMock()
+        request.client = MagicMock()
+        request.client.host = "10.0.0.1"
+        request.url = MagicMock()
+        request.url.path = "/test"
+        request.headers = {}
+        response = MagicMock()
+        response.headers = {}
+
+        with patch("api.middleware.rate_limit.get_rate_limiter", return_value=mock_limiter):
+            dependency = require_rate_limit(5, 60)
+            # Should not raise
+            await dependency(request=request, response=response)
+
+        # Headers should be set
+        assert "RateLimit-Limit" in response.headers
+        assert "RateLimit-Remaining" in response.headers
+        assert "RateLimit-Reset" in response.headers
+
+    @pytest.mark.asyncio
+    async def test_raises_when_over_limit(self) -> None:
+        """Dependency raises RateLimitExceededError when limiter returns False."""
+        from api.middleware.rate_limit import require_rate_limit
+
+        mock_limiter = AsyncMock(spec=RateLimiter)
+        mock_limiter.check.return_value = False
+
+        request = MagicMock()
+        request.client = MagicMock()
+        request.client.host = "10.0.0.1"
+        request.url = MagicMock()
+        request.url.path = "/test"
+        request.headers = {}
+        response = MagicMock()
+        response.headers = {}
+
+        with patch("api.middleware.rate_limit.get_rate_limiter", return_value=mock_limiter):
+            dependency = require_rate_limit(5, 60)
+            with pytest.raises(RateLimitExceededError) as exc_info:
+                await dependency(request=request, response=response)
+
+        assert exc_info.value.retry_after > 0
+
+    @pytest.mark.asyncio
+    async def test_builds_correct_rate_limit_key(self) -> None:
+        """Key format is rate_limit:{ip}:{path}."""
+        from api.middleware.rate_limit import require_rate_limit
+
+        mock_limiter = AsyncMock(spec=RateLimiter)
+        mock_limiter.check.return_value = True
+
+        request = MagicMock()
+        request.client = MagicMock()
+        request.client.host = "192.168.1.1"
+        request.url = MagicMock()
+        request.url.path = "/auth/login"
+        request.headers = {}
+        response = MagicMock()
+        response.headers = {}
+
+        with patch("api.middleware.rate_limit.get_rate_limiter", return_value=mock_limiter):
+            dependency = require_rate_limit(5, 60)
+            await dependency(request=request, response=response)
+
+        mock_limiter.check.assert_called_once_with(
+            key="rate_limit:192.168.1.1:/auth/login",
+            max_requests=5,
+            window_seconds=60,
+        )
+
+    @pytest.mark.asyncio
+    async def test_sets_remaining_header_to_zero_when_at_limit(self) -> None:
+        """RateLimit-Remaining is 0 when at the limit."""
+        from api.middleware.rate_limit import require_rate_limit
+
+        mock_limiter = AsyncMock(spec=RateLimiter)
+        mock_limiter.check.return_value = False
+
+        request = MagicMock()
+        request.client = MagicMock()
+        request.client.host = "10.0.0.1"
+        request.url = MagicMock()
+        request.url.path = "/test"
+        request.headers = {}
+        response = MagicMock()
+        response.headers = {}
+
+        with patch("api.middleware.rate_limit.get_rate_limiter", return_value=mock_limiter):
+            dependency = require_rate_limit(5, 60)
+            with pytest.raises(RateLimitExceededError):
+                await dependency(request=request, response=response)
+
+        assert response.headers["RateLimit-Remaining"] == "0"
+        assert response.headers["RateLimit-Limit"] == "5"

--- a/tests/unit/test_rate_limiting/test_t8_rate_limit_middleware.py
+++ b/tests/unit/test_rate_limiting/test_t8_rate_limit_middleware.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -87,10 +87,9 @@ class TestRequireRateLimitFactory:
         response = MagicMock()
         response.headers = {}
 
-        with patch("api.middleware.rate_limit.get_rate_limiter", return_value=mock_limiter):
-            dependency = require_rate_limit(5, 60)
-            # Should not raise
-            await dependency(request=request, response=response)
+        dep = require_rate_limit(5, 60)
+        # Should not raise
+        await dep(request=request, response=response, limiter=mock_limiter)
 
         # Headers should be set
         assert "RateLimit-Limit" in response.headers
@@ -114,10 +113,9 @@ class TestRequireRateLimitFactory:
         response = MagicMock()
         response.headers = {}
 
-        with patch("api.middleware.rate_limit.get_rate_limiter", return_value=mock_limiter):
-            dependency = require_rate_limit(5, 60)
-            with pytest.raises(RateLimitExceededError) as exc_info:
-                await dependency(request=request, response=response)
+        dep = require_rate_limit(5, 60)
+        with pytest.raises(RateLimitExceededError) as exc_info:
+            await dep(request=request, response=response, limiter=mock_limiter)
 
         assert exc_info.value.retry_after > 0
 
@@ -138,9 +136,8 @@ class TestRequireRateLimitFactory:
         response = MagicMock()
         response.headers = {}
 
-        with patch("api.middleware.rate_limit.get_rate_limiter", return_value=mock_limiter):
-            dependency = require_rate_limit(5, 60)
-            await dependency(request=request, response=response)
+        dep = require_rate_limit(5, 60)
+        await dep(request=request, response=response, limiter=mock_limiter)
 
         mock_limiter.check.assert_called_once_with(
             key="rate_limit:192.168.1.1:/auth/login",
@@ -165,10 +162,9 @@ class TestRequireRateLimitFactory:
         response = MagicMock()
         response.headers = {}
 
-        with patch("api.middleware.rate_limit.get_rate_limiter", return_value=mock_limiter):
-            dependency = require_rate_limit(5, 60)
-            with pytest.raises(RateLimitExceededError):
-                await dependency(request=request, response=response)
+        dep = require_rate_limit(5, 60)
+        with pytest.raises(RateLimitExceededError):
+            await dep(request=request, response=response, limiter=mock_limiter)
 
         assert response.headers["RateLimit-Remaining"] == "0"
         assert response.headers["RateLimit-Limit"] == "5"

--- a/tests/unit/test_rate_limiting/test_t9_dependencies.py
+++ b/tests/unit/test_rate_limiting/test_t9_dependencies.py
@@ -1,0 +1,112 @@
+"""T9: Unit tests for get_redis_client() and get_rate_limiter() dependency providers."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from config.settings import AppSettings
+from domain.rate_limiting.ports import RateLimiter
+from infrastructure.rate_limiting.noop_rate_limiter import NoOpRateLimiter
+from infrastructure.rate_limiting.redis_rate_limiter import RedisRateLimiter
+
+
+TEST_SECRET = "test-secret-key-at-least-32-chars-long"
+
+
+class TestGetRedisClient:
+    """Tests for get_redis_client() provider."""
+
+    def test_returns_redis_client(self) -> None:
+        """Provider returns a Redis client from settings REDIS_URL."""
+        from api.dependencies import get_redis_client
+
+        settings = AppSettings(
+            DATABASE_URL="memory://",
+            SECRET_KEY=TEST_SECRET,
+            REDIS_URL="redis://localhost:6379/0",
+        )
+        client = get_redis_client(settings)
+        assert client is not None
+
+    def test_returns_async_redis_instance(self) -> None:
+        """Provider returns redis.asyncio.Redis instance."""
+        import redis.asyncio
+
+        from api.dependencies import get_redis_client
+
+        settings = AppSettings(
+            DATABASE_URL="memory://",
+            SECRET_KEY=TEST_SECRET,
+        )
+        client = get_redis_client(settings)
+        assert isinstance(client, redis.asyncio.Redis)
+
+
+class TestGetRateLimiter:
+    """Tests for get_rate_limiter() provider."""
+
+    def _reset_singleton(self) -> None:
+        """Reset the rate limiter singleton for test isolation."""
+        import api.dependencies as deps
+        deps._rate_limiter = None
+
+    def teardown_method(self) -> None:
+        """Clean up after each test."""
+        self._reset_singleton()
+
+    def test_returns_noop_when_disabled(self) -> None:
+        """Returns NoOpRateLimiter when RATE_LIMIT_ENABLED=False."""
+        from api.dependencies import get_rate_limiter
+
+        settings = AppSettings(
+            DATABASE_URL="memory://",
+            SECRET_KEY=TEST_SECRET,
+            RATE_LIMIT_ENABLED=False,
+        )
+        with patch("api.dependencies.get_settings", return_value=settings):
+            limiter = get_rate_limiter()
+        assert isinstance(limiter, NoOpRateLimiter)
+        assert isinstance(limiter, RateLimiter)
+
+    def test_returns_noop_when_memory_database(self) -> None:
+        """Returns NoOpRateLimiter when DATABASE_URL=memory://."""
+        from api.dependencies import get_rate_limiter
+
+        settings = AppSettings(
+            DATABASE_URL="memory://",
+            SECRET_KEY=TEST_SECRET,
+            RATE_LIMIT_ENABLED=True,
+        )
+        with patch("api.dependencies.get_settings", return_value=settings):
+            limiter = get_rate_limiter()
+        assert isinstance(limiter, NoOpRateLimiter)
+
+    def test_returns_redis_limiter_when_enabled(self) -> None:
+        """Returns RedisRateLimiter when RATE_LIMIT_ENABLED=True and not memory://."""
+        from api.dependencies import get_rate_limiter
+
+        settings = AppSettings(
+            DATABASE_URL="sqlite:///test.db",
+            SECRET_KEY=TEST_SECRET,
+            RATE_LIMIT_ENABLED=True,
+            REDIS_URL="redis://localhost:6379/0",
+        )
+        with patch("api.dependencies.get_settings", return_value=settings):
+            limiter = get_rate_limiter()
+        assert isinstance(limiter, RedisRateLimiter)
+        assert isinstance(limiter, RateLimiter)
+
+    def test_singleton_returns_same_instance(self) -> None:
+        """Subsequent calls return the same limiter instance."""
+        from api.dependencies import get_rate_limiter
+
+        settings = AppSettings(
+            DATABASE_URL="memory://",
+            SECRET_KEY=TEST_SECRET,
+        )
+        with patch("api.dependencies.get_settings", return_value=settings):
+            limiter1 = get_rate_limiter()
+            limiter2 = get_rate_limiter()
+        assert limiter1 is limiter2

--- a/tests/unit/test_rate_limiting/test_t9_dependencies.py
+++ b/tests/unit/test_rate_limiting/test_t9_dependencies.py
@@ -4,13 +4,10 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-import pytest
-
 from config.settings import AppSettings
 from domain.rate_limiting.ports import RateLimiter
 from infrastructure.rate_limiting.noop_rate_limiter import NoOpRateLimiter
 from infrastructure.rate_limiting.redis_rate_limiter import RedisRateLimiter
-
 
 TEST_SECRET = "test-secret-key-at-least-32-chars-long"
 
@@ -26,7 +23,7 @@ class TestGetRedisClient:
 
     def test_returns_redis_client(self) -> None:
         """Provider returns a Redis client from settings REDIS_URL."""
-        from api.dependencies import get_redis_client, get_settings
+        from api.dependencies import get_redis_client
 
         self._reset_singleton()
         settings = AppSettings(

--- a/tests/unit/test_rate_limiting/test_t9_dependencies.py
+++ b/tests/unit/test_rate_limiting/test_t9_dependencies.py
@@ -18,16 +18,24 @@ TEST_SECRET = "test-secret-key-at-least-32-chars-long"
 class TestGetRedisClient:
     """Tests for get_redis_client() provider."""
 
+    def _reset_singleton(self) -> None:
+        """Reset singletons for test isolation."""
+        import api.dependencies as deps
+        deps._settings = None
+        deps._rate_limiter = None
+
     def test_returns_redis_client(self) -> None:
         """Provider returns a Redis client from settings REDIS_URL."""
-        from api.dependencies import get_redis_client
+        from api.dependencies import get_redis_client, get_settings
 
+        self._reset_singleton()
         settings = AppSettings(
             DATABASE_URL="memory://",
             SECRET_KEY=TEST_SECRET,
             REDIS_URL="redis://localhost:6379/0",
         )
-        client = get_redis_client(settings)
+        with patch("api.dependencies.get_settings", return_value=settings):
+            client = get_redis_client()
         assert client is not None
 
     def test_returns_async_redis_instance(self) -> None:
@@ -36,11 +44,13 @@ class TestGetRedisClient:
 
         from api.dependencies import get_redis_client
 
+        self._reset_singleton()
         settings = AppSettings(
             DATABASE_URL="memory://",
             SECRET_KEY=TEST_SECRET,
         )
-        client = get_redis_client(settings)
+        with patch("api.dependencies.get_settings", return_value=settings):
+            client = get_redis_client()
         assert isinstance(client, redis.asyncio.Redis)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -17,6 +17,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "pyjwt" },
     { name = "python-dotenv" },
+    { name = "redis", extra = ["hiredis"] },
     { name = "sqlmodel" },
     { name = "structlog" },
 ]
@@ -38,6 +39,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "pyjwt", specifier = ">=2.8.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
+    { name = "redis", extras = ["hiredis"], specifier = ">=5.0" },
     { name = "sqlmodel", specifier = ">=0.0.22" },
     { name = "structlog", specifier = ">=24.0.0" },
 ]
@@ -441,6 +443,53 @@ wheels = [
 ]
 
 [[package]]
+name = "hiredis"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/97/d6/9bef6dc3052c168c93fbf7e6c0f2b12c45f0f741a2d30fd919096774343a/hiredis-3.3.1.tar.gz", hash = "sha256:da6f0302360e99d32bc2869772692797ebadd536e1b826d0103c72ba49d38698", size = 89101, upload-time = "2026-03-16T15:21:08.092Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/4b/c7f4d6d6643622f296395269e24b02c69d4ac72822f052b8cae16fa3af03/hiredis-3.3.1-cp313-cp313-macosx_10_15_universal2.whl", hash = "sha256:afe3c3863f16704fb5d7c2c6ff56aaf9e054f6d269f7b4c9074c5476178d1aba", size = 82027, upload-time = "2026-03-16T15:19:48.002Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/45/198be960a7443d6eb5045751e929480929c0defbca316ce1a47d15187330/hiredis-3.3.1-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:f19ee7dc1ef8a6497570d91fa4057ba910ad98297a50b8c44ff37589f7c89d17", size = 46220, upload-time = "2026-03-16T15:19:48.953Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/a4/6ab925177f289830008dbe1488a9858675e2e234f48c9c1653bd4d0eaddc/hiredis-3.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:09f5e510f637f2c72d2a79fb3ad05f7b6211e057e367ca5c4f97bb3d8c9d71f4", size = 41858, upload-time = "2026-03-16T15:19:49.939Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c8/a0ddbb9e9c27fcb0022f7b7e93abc75727cb634c6a5273ca5171033dac78/hiredis-3.3.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b46e96b50dad03495447860510daebd2c96fd44ed25ba8ccb03e9f89eaa9d34", size = 170095, upload-time = "2026-03-16T15:19:51.216Z" },
+    { url = "https://files.pythonhosted.org/packages/94/06/618d509cc454912028f71995f3dd6eb54606f0aa8163ff79c5b7ec1f2bda/hiredis-3.3.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b4fe7f38aa8956fcc1cea270e62601e0e11066aff78e384be70fd283d30293b6", size = 181745, upload-time = "2026-03-16T15:19:52.72Z" },
+    { url = "https://files.pythonhosted.org/packages/06/14/75b2deb62a61fc75a41ce1a6a781fe239133bbc88fef404d32a148ad152a/hiredis-3.3.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2b96da7e365d6488d2a75266a662cbe3cc14b28c23dd9b0c9aa04b5bc5c20192", size = 180465, upload-time = "2026-03-16T15:19:53.847Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/8c/8e03dcbfde8e2ca3f880fce06ad0877b3f098ed5fdfb17cf3b821a32323a/hiredis-3.3.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:52d5641027d6731bc7b5e7d126a5158a99784a9f8c6de3d97ca89aca4969e9f8", size = 172419, upload-time = "2026-03-16T15:19:54.959Z" },
+    { url = "https://files.pythonhosted.org/packages/03/05/843005d68403a3805309075efc6638360a3ababa6cb4545163bf80c8e7f7/hiredis-3.3.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:eddeb9a153795cf6e615f9f3cef66a1d573ff3b6ee16df2b10d1d1c2f2baeaa8", size = 166398, upload-time = "2026-03-16T15:19:56.36Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/23/abe2476244fd792f5108009ec0ae666eaa5b2165ca19f2e86638d8324ac9/hiredis-3.3.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:011a9071c3df4885cac7f58a2623feac6c8e2ad30e6ba93c55195af05ce61ff5", size = 176844, upload-time = "2026-03-16T15:19:57.462Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/47/e1cdccc559b98e548bcff0868c3938d375663418c0adca465895ee1f72e7/hiredis-3.3.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:264ee7e9cb6c30dc78da4ecf71d74cf14ca122817c665d838eda8b4384bce1b0", size = 170366, upload-time = "2026-03-16T15:19:58.548Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/e1/fda8325f51d06877e8e92500b15d4aff3855b4c3c91dbd9636a82e4591f2/hiredis-3.3.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d1434d0bcc1b3ef048bae53f26456405c08aeed9827e65b24094f5f3a6793f1", size = 168023, upload-time = "2026-03-16T15:19:59.727Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/21/2839d1625095989c116470e2b6841bbe1a2a5509585e82a4f3f5cd47f511/hiredis-3.3.1-cp313-cp313-win32.whl", hash = "sha256:f915a34fb742e23d0d61573349aa45d6f74037fde9d58a9f340435eff8d62736", size = 20535, upload-time = "2026-03-16T15:20:00.938Z" },
+    { url = "https://files.pythonhosted.org/packages/84/f9/534c2a89b24445a9a9623beb4697fd72b8c8f16286f6f3bda012c7af004a/hiredis-3.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:d8e56e0d1fe607bfff422633f313aec9191c3859ab99d11ff097e3e6e068000c", size = 22383, upload-time = "2026-03-16T15:20:01.865Z" },
+    { url = "https://files.pythonhosted.org/packages/03/72/0450d6b449da58120c5497346eb707738f8f67b9e60c28a8ef90133fc81f/hiredis-3.3.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:439f9a5cc8f9519ce208a24cdebfa0440fef26aa682a40ba2c92acb10a53f5e0", size = 82112, upload-time = "2026-03-16T15:20:02.865Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c0/0be33a29bcd463e6cbb0282515dd4d0cdfe33c30c7afc6d4d8c460e23266/hiredis-3.3.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3724f0e58c6ff76fd683429945491de71324ab1bc0ad943a8d68cb0932d24075", size = 46238, upload-time = "2026-03-16T15:20:03.896Z" },
+    { url = "https://files.pythonhosted.org/packages/62/f2/f999854bfaf3bcbee0f797f24706c182ecfaca825f6a582f6281a6aa97e0/hiredis-3.3.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:29fe35e3c6fe03204e75c86514f452591957a1e06b05d86e10d795455b71c355", size = 41891, upload-time = "2026-03-16T15:20:04.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c8/cd9ab90fec3a301d864d8ab6167aea387add8e2287969d89cbcd45d6b0e0/hiredis-3.3.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d42f3a13290f89191568fc113d95a3d2c8759cdd8c3672f021d8b7436f909e75", size = 170485, upload-time = "2026-03-16T15:20:06.284Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/9a/1ddf9ea236a292963146cbaf6722abeb9d503ca47d821267bb8b3b81c4f7/hiredis-3.3.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2afc675b831f7552da41116fffffca4340f387dc03f56d6ec0c7895ab0b59a10", size = 182030, upload-time = "2026-03-16T15:20:07.857Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/b8/e070a1dbf8a1bbb8814baa0b00836fbe3f10c7af8e11f942cc739c64e062/hiredis-3.3.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4106201cd052d9eabe3cb7b5a24b0fe37307792bda4fcb3cf6ddd72f697828e8", size = 180543, upload-time = "2026-03-16T15:20:09.096Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bb/b5f4f98e44626e2446cd8a52ce6cb1fc1c99786b6e2db3bf09cea97b90cd/hiredis-3.3.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8887bf0f31e4b550bd988c8863b527b6587d200653e9375cd91eea2b944b7424", size = 172356, upload-time = "2026-03-16T15:20:10.245Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/93/73a77b54ba94e82f76d02563c588d8a062513062675f483a033a43015f2c/hiredis-3.3.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1ac7697365dbe45109273b34227fee6826b276ead9a4a007e0877e1d3f0fcf21", size = 166433, upload-time = "2026-03-16T15:20:11.789Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c2/1b2dcbe5dc53a46a8cb05bed67d190a7e30bad2ad1f727ebe154dfeededd/hiredis-3.3.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2b6da6e07359107c653a809b3cff2d9ccaeedbafe33c6f16434aef6f53ce4a2b", size = 177220, upload-time = "2026-03-16T15:20:12.991Z" },
+    { url = "https://files.pythonhosted.org/packages/02/09/f4314cf096552568b5ea785ceb60c424771f4d35a76c410ad39d258f74bc/hiredis-3.3.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:ce334915f5d31048f76a42c607bf26687cf045eb1bc852b7340f09729c6a64fc", size = 170475, upload-time = "2026-03-16T15:20:14.519Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/2e/3f56e438efc8fc27ed4a3dbad58c0280061466473ec35d8f86c90c841a84/hiredis-3.3.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ee11fd431f83d8a5b29d370b9d79a814d3218d30113bdcd44657e9bdf715fc92", size = 167913, upload-time = "2026-03-16T15:20:15.672Z" },
+    { url = "https://files.pythonhosted.org/packages/56/34/053e5ee91d6dc478faac661996d1fd4886c5acb7a1b5ac30e7d3c794bb51/hiredis-3.3.1-cp314-cp314-win32.whl", hash = "sha256:e0356561b4a97c83b9ee3de657a41b8d1a1781226853adaf47b550bb988fda6f", size = 21167, upload-time = "2026-03-16T15:20:17.013Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/33/06776c641d17881a9031e337e81b3b934c38c2adbb83c85062d6b5f83b72/hiredis-3.3.1-cp314-cp314-win_amd64.whl", hash = "sha256:80aba5f85d6227faee628ae28d1c3b69c661806a0636548ac56c68782606454f", size = 23000, upload-time = "2026-03-16T15:20:17.966Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/5a/94f9a505b2ff5376d4a05fb279b69d89bafa7219dd33f6944026e3e56f80/hiredis-3.3.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:907f7b5501a534030738f0f27459a612d2266fd0507b007bb8f3e6de08167920", size = 83039, upload-time = "2026-03-16T15:20:19.316Z" },
+    { url = "https://files.pythonhosted.org/packages/93/ae/d3752a8f03a1fca43d402389d2a2d234d3db54c4d1f07f26c1041ca3c5de/hiredis-3.3.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:de94b409f49eb6a588ebdd5872e826caec417cd77c17af0fb94f2128427f1a2a", size = 46703, upload-time = "2026-03-16T15:20:20.401Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/76/e32c868a2fa23cd82bacaffd38649d938173244a0e717ec1c0c76874dbdd/hiredis-3.3.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:79cd03e7ff550c17758a7520bf437c156d3d4c8bb74214deeafa69cda49c85a4", size = 42379, upload-time = "2026-03-16T15:20:21.705Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/f6/d687d36a74ce6cf448826cf2e8edfc1eb37cc965308f74eb696aa97c69df/hiredis-3.3.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6ffa7ba2e2da1f806f3181b9730b3e87ba9dbfec884806725d4584055ba3faa6", size = 180311, upload-time = "2026-03-16T15:20:23.037Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ac/f520dc0066a62a15aa920c7dd0a2028c213f4862d5f901409ae92ee5d785/hiredis-3.3.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ee37fe8cf081b72dea72f96a0ee604f492ec02252eb77dc26ff6eec3f997b580", size = 190488, upload-time = "2026-03-16T15:20:24.357Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/f5/ae10fff82d0f291e90c41bf10a5d6543a96aae00cccede01bf2b6f7e178d/hiredis-3.3.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9bfdeff778d3f7ff449ca5922ab773899e7d31e26a576028b06a5e9cf0ed8c34", size = 189210, upload-time = "2026-03-16T15:20:25.51Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/8f/5be4344e542aa8d349a03d05486c59d9ca26f69c749d11e114bf34b84d50/hiredis-3.3.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:027ce4fabfeff5af5b9869d5524770877f9061d118bc36b85703ae3faf5aad8e", size = 180971, upload-time = "2026-03-16T15:20:26.631Z" },
+    { url = "https://files.pythonhosted.org/packages/41/a2/29e230226ec2a31f13f8a832fbafe366e263f3b090553ebe49bb4581a7bd/hiredis-3.3.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:dcea8c3f53674ae68e44b12e853b844a1d315250ca6677b11ec0c06aff85e86c", size = 175314, upload-time = "2026-03-16T15:20:27.848Z" },
+    { url = "https://files.pythonhosted.org/packages/89/2e/bf241707ad86b9f3ebfbc7ab89e19d5ec243ff92ca77644a383622e8740b/hiredis-3.3.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0b5ff2f643f4b452b0597b7fe6aa35d398cb31d8806801acfafb1558610ea2aa", size = 185652, upload-time = "2026-03-16T15:20:29.364Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c1/b39170d8bcccd01febd45af4ac6b43ff38e134a868e2ec167a82a036fb35/hiredis-3.3.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:3586c8a5f56d34b9dddaaa9e76905f31933cac267251006adf86ec0eef7d0400", size = 179033, upload-time = "2026-03-16T15:20:30.549Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/3a/4fe39a169115434f911abff08ff485b9b6201c168500e112b3f6a8110c0a/hiredis-3.3.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a110d19881ca78a88583d3b07231e7c6864864f5f1f3491b638863ea45fa8708", size = 176126, upload-time = "2026-03-16T15:20:31.958Z" },
+    { url = "https://files.pythonhosted.org/packages/44/99/c1d0b0bc4f9e9150e24beb0dca2e186e32d5e749d0022e0d26453749ed51/hiredis-3.3.1-cp314-cp314t-win32.whl", hash = "sha256:98fd5b39410e9d69e10e90d0330e35650becaa5dd2548f509b9598f1f3c6124d", size = 22028, upload-time = "2026-03-16T15:20:33.33Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d6/191e6741addc97bcf5e755661f8c82f0fd0aa35f07ece56e858da689b57e/hiredis-3.3.1-cp314-cp314t-win_amd64.whl", hash = "sha256:ab1f646ff531d70bfd25f01e60708dfa3d105eb458b7dedd9fe9a443039fd809", size = 23811, upload-time = "2026-03-16T15:20:34.292Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -823,6 +872,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "redis"
+version = "7.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/7f/3759b1d0d72b7c92f0d70ffd9dc962b7b7b5ee74e135f9d7d8ab06b8a318/redis-7.4.0.tar.gz", hash = "sha256:64a6ea7bf567ad43c964d2c30d82853f8df927c5c9017766c55a1d1ed95d18ad", size = 4943913, upload-time = "2026-03-24T09:14:37.53Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/3a/95deec7db1eb53979973ebd156f3369a72732208d1391cd2e5d127062a32/redis-7.4.0-py3-none-any.whl", hash = "sha256:a9c74a5c893a5ef8455a5adb793a31bb70feb821c86eccb62eebef5a19c429ec", size = 409772, upload-time = "2026-03-24T09:14:35.968Z" },
+]
+
+[package.optional-dependencies]
+hiredis = [
+    { name = "hiredis" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -24,6 +24,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "fakeredis", extra = ["lua"] },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -46,6 +47,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "fakeredis", extras = ["lua"], specifier = ">=2.21" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=0.24.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
@@ -277,6 +279,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
+]
+
+[[package]]
+name = "fakeredis"
+version = "2.35.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "redis" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/50/b748233c02fa77e5105238190cc9bb58b852eb1c8b1d0763230d3a5b745a/fakeredis-2.35.1.tar.gz", hash = "sha256:5bae5eba7b9d93cb968944ac40936373cf2397ff71667d4b595df65c3d2e413f", size = 189118, upload-time = "2026-04-12T17:05:58.539Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/27/b8b057a23f7777177e92d3a602fd866751b6b45014964548997e92e048fd/fakeredis-2.35.1-py3-none-any.whl", hash = "sha256:67d97e11f562b7870e11e5c30cf182270bfb2dd37f6707dba47cc6d91628d1b9", size = 129678, upload-time = "2026-04-12T17:05:56.86Z" },
+]
+
+[package.optional-dependencies]
+lua = [
+    { name = "lupa" },
 ]
 
 [[package]]
@@ -567,6 +587,54 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "lupa"
+version = "2.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/a6/0f869fbb07c393f15473b1eefefb7b5bec162fb7481803d040ed4dc46002/lupa-2.8.tar.gz", hash = "sha256:d8022641b9ec8ecf2c5ecbe9f47e5a70e0b87c4b5ae921b92cb02a638e0acd08", size = 6156370, upload-time = "2026-04-15T20:08:30.534Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/21/9be4516ddd22f8eadba336d9ba065d17d79108465ae1b7f71424ab99b9d0/lupa-2.8-cp310-abi3-win32.whl", hash = "sha256:c2a5fd15dc62374e1661a55f01744c9ec1c56f291ba4a0749d3af2174556e78f", size = 1594887, upload-time = "2026-04-15T20:05:23.377Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/99/1557c9685d7034d9ce8dd2b54c40a26d6deb7c67c1fdb5c801abd1a02c3f/lupa-2.8-cp310-abi3-win_arm64.whl", hash = "sha256:9e304fb1c50cf23fd8882afbe1aa87525ef8a72667bcab3b37b2bbb2bc542269", size = 1371742, upload-time = "2026-04-15T20:05:27.417Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/0b/368f2f0bc750b25c69d4563e44f677925ab5dd3d2887f9b0c15465d21a2a/lupa-2.8-cp312-abi3-macosx_10_13_x86_64.whl", hash = "sha256:f4342f4de76ae7ce2ab0672d36003bdb7e1a33252f293b569298ddd792e70e33", size = 1194056, upload-time = "2026-04-15T20:05:55.794Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/0f/c89eb8dd36fdea4e50ae3f7f5275bea3b0cc5d4057b8ee7b3bbc78010422/lupa-2.8-cp312-abi3-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:4203fa1659315e939a5304e75001b8cc14234fb3cbb3ed86c049b0cc5d90fcee", size = 1434278, upload-time = "2026-04-15T20:05:57.94Z" },
+    { url = "https://files.pythonhosted.org/packages/47/30/c3b4d2cd8733621b404b8a4214e5f852955c4ba632546dc84123bea9ee89/lupa-2.8-cp312-abi3-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:81f2d843ce668b653146c007467570210ae44be51dac6926666c51d49536f307", size = 1150068, upload-time = "2026-04-15T20:06:01.04Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/d2/bac12c398519efafc6af84be1974edd0d7a4895fb4735b5c8d615d298595/lupa-2.8-cp312-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d3d0cde2c77588d1c60875a4f34f059513476c6e1775351897195b51e0f3df08", size = 1409532, upload-time = "2026-04-15T20:06:03.592Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6a/18b52e11962014026e07813530b0b108ee8bc0a2a13ef0eaea5d41dce023/lupa-2.8-cp312-abi3-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9e0d11b8f3a8dac6413f704fef7161d048bb10c58bdac6cbffa5e60efa56e9a3", size = 1242687, upload-time = "2026-04-15T20:06:06.863Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/8e/7fd4eb049875f61429b96780d2eae4700f0e78fe0a52db8edb231b1cd09f/lupa-2.8-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:54cff414f21f8cd8c6be4aae52541f3b9cd39602b59e3a3db9b5c9f9f674ff18", size = 1856038, upload-time = "2026-04-15T20:06:09.358Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f9/37ad9d2773d30f2931890d310a4bdce28d45484206e6f48bc18b0325eabd/lupa-2.8-cp312-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:24b4d8af5558e549b70daf1547f5c1c1d664ecea9fc790f83efe5d75e9a93797", size = 1128982, upload-time = "2026-04-15T20:06:12.312Z" },
+    { url = "https://files.pythonhosted.org/packages/57/31/c0fd7984c24844ea79caa45c0235f61a06b38fd69a839f6c62770f8d684a/lupa-2.8-cp312-abi3-musllinux_1_2_i686.whl", hash = "sha256:ce86dff1ee7f7cf45f5622065ae991949dd7bb1703581cbc58a630137bb7ccf9", size = 1457594, upload-time = "2026-04-15T20:06:15.881Z" },
+    { url = "https://files.pythonhosted.org/packages/11/f5/a28e411be30ec1bf0db1eb0c087eebc73be9e7a1adcfe6ac209861ccc446/lupa-2.8-cp312-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:f4d01b2a08c70bbb883a9e082b6b36b89121ed5910b710f1ba11c73295ff4fba", size = 1425721, upload-time = "2026-04-15T20:06:18.009Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/c1/359f767c4ae024be30d909fe8a9f0e9af266bad47ce2bd2ed248fb986fcf/lupa-2.8-cp312-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:7f210d5a8353e510ea1199c42cf3cbdd630553bf2bc8fb4c00fea06fdec7c798", size = 1253258, upload-time = "2026-04-15T20:06:21.17Z" },
+    { url = "https://files.pythonhosted.org/packages/17/52/473f11790c261fd02bbf318a546fe040e9ec9f677181272fa78d3b4112a4/lupa-2.8-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4f81a02806e7c7ad26d8c6fa222c8bef1b0c1b124347c879be880b41339d41e4", size = 2395272, upload-time = "2026-04-15T20:06:24.137Z" },
+    { url = "https://files.pythonhosted.org/packages/94/bf/75c8795655a8836eab6a11a630352c4b7c5dc5c54d075077bc9bffdeee45/lupa-2.8-cp312-abi3-win32.whl", hash = "sha256:360056453a7a4eaa4ac5a204c31a5a014b1eb2ee5490603234d2ba831684f1f2", size = 1606136, upload-time = "2026-04-15T20:06:27.815Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/29/11a2cdd612b6f55e506292dfb6ba343216e80a693e7fe3f876ef204ce9c6/lupa-2.8-cp312-abi3-win_arm64.whl", hash = "sha256:1628371c6592a6d5650497a9e31fb2bb3a7e9883c1f301d1111265e484045af9", size = 1364495, upload-time = "2026-04-15T20:06:30.254Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/3f/19f83c3a0c84dc8bea8a58e7416dca6a3ede662c33c8d1ec758e5afc754a/lupa-2.8-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45fc9da0145ecb0083ef5ff9975116cc784bd0258bdc2bd131ba15483ce18398", size = 1201203, upload-time = "2026-04-15T20:06:42.169Z" },
+    { url = "https://files.pythonhosted.org/packages/89/0f/a14f0073f09610158038582e230618a48c14da6bd88185289461aa4cb854/lupa-2.8-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:58e18afed57955b41130e269c78f53d4123ab86e236b53816f4cbffa25cb5d30", size = 1806210, upload-time = "2026-04-15T20:06:45.486Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/14/48fff156c63a136001a7620878af7d31aa07e66b495ed621e3eddd73c294/lupa-2.8-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fc47f536ac13a79cef47d29a2b205576a22841f042a2bcec1676b95806e7706a", size = 2359005, upload-time = "2026-04-15T20:06:47.819Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/18/3ac638ec90edf178242b8a2b2f00f8adae694248c03a26341ef941bb746e/lupa-2.8-cp313-cp313-win_amd64.whl", hash = "sha256:ce9404c661dbac65cc9bed351ad45e797af93d30d70be309a3fa8209ac86d93b", size = 1936754, upload-time = "2026-04-15T20:06:50.448Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ef/5ee5fed6ea7459a671196359ce04bfeeaf26be1dac8ff24bf28e5c7a6e81/lupa-2.8-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:348c3f8ecabb6324dcbc05c2740d762ef8fcec7b06c79e45262ab97a217684e3", size = 1209388, upload-time = "2026-04-15T20:06:53.022Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/b1/67a940d5542cb0384b443fe951b5a83ea9340d1333a733a258fdd1c619ba/lupa-2.8-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:951496471056061598a7d1729a6cdf48d662fec777a9f2d8aa5a1e62fd30e5a5", size = 1826821, upload-time = "2026-04-15T20:06:55.699Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/a2/b354e5ba3b911ec50686003dc8897e892b9e8c5c036b33219b03d54c4daf/lupa-2.8-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a591b9947ca347b41a63370e121d6e2b1458fe6dde9ae065029ec10a37f25ff4", size = 2366893, upload-time = "2026-04-15T20:06:58.9Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/52/d76066401f29539df5352f70ecded66576f32933b6045cd0bfc56cb770b9/lupa-2.8-cp314-cp314-win_amd64.whl", hash = "sha256:3903c9cf628dae2f56405503247b77a61a3a61bd2dda470e336950c74776d55d", size = 1994716, upload-time = "2026-04-15T20:07:19.194Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/bd/3efc437a4361c16d25e66478c50357c9a8e8ecfb718fe749eb9ca3176ef6/lupa-2.8-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f711a8ab0486b9ac6fdda94a22ddcfbc9f0d4a27e3a8cf1bf79c6e48b33017c1", size = 1251217, upload-time = "2026-04-15T20:07:01.64Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f4/2e9f8ecbaca854bfdf14af8a9b505ec0cbc640377b3b218921594b7563cd/lupa-2.8-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc51250e76367a3e27fcd01dc769b9bfcbbc34f48df48dde53d6af6e75b7eaa5", size = 1814701, upload-time = "2026-04-15T20:07:04.149Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/53/4000b1acaa8b1f3827fcff0cfcdff44d3befddda42cab7e685a49689b5a1/lupa-2.8-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f8a22088a552828958603323f0a5c4b3e11e03b75d0bf4c965ef879de9b60a8d", size = 2348414, upload-time = "2026-04-15T20:07:07.285Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/78/26ee48d3890cddf03cefb65f433e3492759c0b3c0582180755bddbaab7bd/lupa-2.8-cp314-cp314t-win32.whl", hash = "sha256:4f7c553c1d8cfffbe85d81daef730d12cae4b6002d457542914da0ac8a1145b3", size = 1831611, upload-time = "2026-04-15T20:07:09.752Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d1/4a5cc64a3cad22821ae4c3f7a90456a08ca19457d8354f4abf46ad03c7e8/lupa-2.8-cp314-cp314t-win_amd64.whl", hash = "sha256:d8766aff03a78c80ad2d188a8bdb216de5ec838359cd87e05bbdfa56394a6105", size = 2209250, upload-time = "2026-04-15T20:07:11.906Z" },
+    { url = "https://files.pythonhosted.org/packages/37/7c/cdcb654daf668192aaf36b0aeb94f2281dad092aaa5003688691131736ea/lupa-2.8-cp314-cp314t-win_arm64.whl", hash = "sha256:91d622777febda3ab1bed1d45295f2f32a4680c7b3d7caf8c669998ed5c44118", size = 1126735, upload-time = "2026-04-15T20:07:15.434Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/44/de1961ad38e17cd326a53c246c7e3b91178ed578f4cf22ffcd5e7e11b041/lupa-2.8-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b036738282a5acd2e71fdddb317c9df8b87c1673aa57f403d05fcc2be8abc4ba", size = 1186020, upload-time = "2026-04-15T20:07:35.017Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c2/276f0b9dc8bcc5a8a58af5316dfa0e6f56be3613dd6dbcc8d3d2cb6559ba/lupa-2.8-cp39-abi3-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:ac6b6e8d0e617e26a98cbb44880bcd75de5d32b3ad7b3b3793583909292b47ed", size = 1468944, upload-time = "2026-04-15T20:07:37.782Z" },
+    { url = "https://files.pythonhosted.org/packages/63/38/52934e52a5180dc6425d20284d004fe4b27a4f9171a82dc99fb67af250bf/lupa-2.8-cp39-abi3-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:ba3a7dd839f90c3d2e53bebe3c192b1f3f9fd720a6781256405123211fd0dce6", size = 1172998, upload-time = "2026-04-15T20:07:40.812Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/82/76b3809bd0839d9b3b4ec58d06591e08f17337b6d9576877cb9d48b34e94/lupa-2.8-cp39-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d7edb13a7a5250b5c6c22d1495d9e842b5c9fc5081c8fe6b5efe2112fe3e41f9", size = 1449975, upload-time = "2026-04-15T20:07:44.262Z" },
+    { url = "https://files.pythonhosted.org/packages/16/07/2f89d54f747c67c23b4b9ae4aa8c8dd06bb409155dedcf406157f2736b66/lupa-2.8-cp39-abi3-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:891f72e0bffbed1e4175f975aeb2a083956586a100066525e1be485f617f7b25", size = 1281944, upload-time = "2026-04-15T20:07:46.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/bd/7375d2b0fcae79d806baf52a76f26c96964593f58e1372d13ae5ac09c676/lupa-2.8-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:a295f87b5b7ebbfd5191932e8cb0e51df3c7769101ac6b6c7d7c9fb27bfd1307", size = 1910455, upload-time = "2026-04-15T20:07:49.75Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/0c/8abb3bc0e08b311fc01db05b6e9f9ff31a8f65e4fc3f0aeb05cfef75c8ac/lupa-2.8-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:4fe5d7a810b64ea8511eb885fc8cdde042ee5ff7b7d08ae78f32449756acb177", size = 1155548, upload-time = "2026-04-15T20:07:52.657Z" },
+    { url = "https://files.pythonhosted.org/packages/80/2e/9eeecd3f493099721c1d3f31beeca23a4237db1a54223684df4dc96aa1bd/lupa-2.8-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:bfc470012ef66ad064c7bd77416af03a3452ef630b04b9012595ea13f2e54518", size = 1489232, upload-time = "2026-04-15T20:07:54.92Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/13/731c99dc2e7652ae818a6de45bdf0142049f7cb566049061c898355f1891/lupa-2.8-cp39-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:250e035fdaffe8c87093e3ebc206ac29a26131b1568ea711d780c26001ce96e7", size = 1466321, upload-time = "2026-04-15T20:07:57.627Z" },
+    { url = "https://files.pythonhosted.org/packages/de/71/3ad8cc4fc05a77dc0d3f7079348bd1cad4675a0d14c24f8e6a3ce5f008f7/lupa-2.8-cp39-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:b9bddb09acfffb4f828f790f444b11dc0cca591afea1a244d9329eea2d20c003", size = 1288577, upload-time = "2026-04-15T20:07:59.913Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/b2/1175f6d0aa7b68627fbe2f58bd1e8bea36a89d10dfd67671d2b024c96162/lupa-2.8-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2e64acbbd47e9b82a64405a39e0d2b36a5a7dad8ab41c0f3437f572f7d282ba3", size = 2444866, upload-time = "2026-04-15T20:08:02.753Z" },
 ]
 
 [[package]]
@@ -1013,6 +1081,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implementa rate limiting por endpoint usando Sliding Window con Redis Sorted Sets, siguiendo el patrón de Clean Architecture del proyecto.

## Cambios

### Arquitectura
- Puerto `RateLimiter` (ABC) en `domain/rate_limiting/`
- `RedisRateLimiter` en `infrastructure/rate_limiting/` — sliding window con pipeline atómico
- `NoOpRateLimiter` — fallback cuando Redis no está disponible o `DATABASE_URL=memory://`
- `require_rate_limit()` como `Depends()` factory — mismo patrón que `require_permission()`

### Endpoints
| Endpoint | Límite |
|----------|--------|
| `POST /auth/login` | 5 req/60s |
| `POST /auth/register` | 3 req/60s |
| Resto de endpoints protegidos | 100 req/60s |
| `GET /health` | Sin límite |

### Response
- **200**: Headers `RateLimit-Limit`, `RateLimit-Remaining`, `RateLimit-Reset`
- **429**: `{"detail": "Too many requests"}` + `Retry-After` + los 3 headers IETF

### Settings (8 nuevas en AppSettings)
`RATE_LIMIT_ENABLED`, `RATE_LIMIT_FAIL_OPEN`, `RATE_LIMIT_LOGIN_MAX`, `RATE_LIMIT_LOGIN_WINDOW`, `RATE_LIMIT_REGISTER_MAX`, `RATE_LIMIT_REGISTER_WINDOW`, `RATE_LIMIT_GLOBAL_MAX`, `RATE_LIMIT_GLOBAL_WINDOW`

### Revisión por capas (3 unidades lógicas)
1. **Capa dominio + config** (T1–T4): `RateLimiter` ABC, `RateLimitExceededError`, settings, `redis[hiredis]`
2. **Infraestructura + API** (T5–T13): `RedisRateLimiter`, `NoOpRateLimiter`, middleware, handler 429, wiring
3. **Tests + docs** (T14–T23): 86 tests nuevos, ADR-008, API.md actualizado

### Tests
- **457 tests** (371 existentes + 86 nuevos), 0 regresiones
- Unit: `fakeredis` para Redis, `AsyncMock` para middleware
- Integration: `TestClient` + `NoOpRateLimiter` override en todos los fixtures existentes

### Rollback
`RATE_LIMIT_ENABLED=False` desactiva todo sin cambios de código.

### ADR
`docs/adr/ADR-008-rate-limit.md`

Closes SDD rate-limit